### PR TITLE
type arguments are stripped in fieldsToSqliteColumns (#31)

### DIFF
--- a/packages/brick_build/CHANGELOG.md
+++ b/packages/brick_build/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Rename `ProviderSerializable` to `ProviderSerializableGenerator` to be more explicit
+* Rename `SharedChecker#mapArgs` to `SharedChecker#typeArguments`
 
 ## 0.0.4
 

--- a/packages/brick_build/lib/src/utils/shared_checker.dart
+++ b/packages/brick_build/lib/src/utils/shared_checker.dart
@@ -119,14 +119,13 @@ class SharedChecker<_SiblingModel extends Model> {
 
   bool get isString => _stringChecker.isExactlyType(targetType);
 
-  /// Returns the type arguments of `Map<Key, Value>` as `[Key, Value]`.
-  /// If the Map does not declare type arguments, return is `null`.
-  List<DartType> get mapArgs {
-    assert(isMap, '$targetType is not a Map');
-
+  /// Returns type arguments of [targetType]. For example, given `Map<Key, Value>`,
+  /// `[Key, Value]` is returned. If the [targetType] does not declare type arguments,
+  /// return is `null`.
+  List<DartType> get typeArguments {
     final type = targetType as InterfaceType;
     if (type.typeArguments.isNotEmpty && type.typeArguments.length > 1) {
-      return [type.typeArguments.first, type.typeArguments.last];
+      return type.typeArguments;
     }
 
     return null;

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offlne_first_serdes_with_type_argument.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offlne_first_serdes_with_type_argument.dart
@@ -1,0 +1,96 @@
+import 'package:brick_offline_first_abstract/abstract.dart';
+import 'package:brick_offline_first_abstract/annotations.dart';
+
+final output = r"""
+// GENERATED CODE DO NOT EDIT
+// This file should NOT be version controlled and should not be manually edited.
+part of '../brick.g.dart';
+
+Future<OfflineFirstSerdesWithTypeArgument>
+    _$OfflineFirstSerdesWithTypeArgumentFromRest(Map<String, dynamic> data,
+        {RestProvider provider, OfflineFirstRepository repository}) async {
+  return OfflineFirstSerdesWithTypeArgument();
+}
+
+Future<Map<String, dynamic>> _$OfflineFirstSerdesWithTypeArgumentToRest(
+    OfflineFirstSerdesWithTypeArgument instance,
+    {RestProvider provider,
+    OfflineFirstRepository repository}) async {
+  return {};
+}
+
+Future<OfflineFirstSerdesWithTypeArgument>
+    _$OfflineFirstSerdesWithTypeArgumentFromSqlite(Map<String, dynamic> data,
+        {SqliteProvider provider, OfflineFirstRepository repository}) async {
+  return OfflineFirstSerdesWithTypeArgument()
+    ..primaryKey = data['_brick_id'] as int;
+}
+
+Future<Map<String, dynamic>> _$OfflineFirstSerdesWithTypeArgumentToSqlite(
+    OfflineFirstSerdesWithTypeArgument instance,
+    {SqliteProvider provider,
+    OfflineFirstRepository repository}) async {
+  return {};
+}
+
+/// Construct a [OfflineFirstSerdesWithTypeArgument]
+class OfflineFirstSerdesWithTypeArgumentAdapter
+    extends OfflineFirstAdapter<OfflineFirstSerdesWithTypeArgument> {
+  OfflineFirstSerdesWithTypeArgumentAdapter();
+
+  String restEndpoint({query, instance}) => '';
+  final String fromKey = null;
+  final String toKey = null;
+  final Map<String, Map<String, dynamic>> fieldsToSqliteColumns = {
+    'primaryKey': {
+      'name': '_brick_id',
+      'type': int,
+      'iterable': false,
+      'association': false,
+    },
+    'someField': {
+      'name': 'some_field',
+      'type': SerdesWithTypeArgument,
+      'iterable': false,
+      'association': false,
+    }
+  };
+  Future<int> primaryKeyByUniqueColumns(
+          OfflineFirstSerdesWithTypeArgument instance,
+          DatabaseExecutor executor) async =>
+      null;
+  final String tableName = 'OfflineFirstSerdesWithTypeArgument';
+
+  Future<OfflineFirstSerdesWithTypeArgument> fromRest(
+          Map<String, dynamic> input,
+          {provider,
+          repository}) async =>
+      await _$OfflineFirstSerdesWithTypeArgumentFromRest(input,
+          provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toRest(OfflineFirstSerdesWithTypeArgument input,
+          {provider, repository}) async =>
+      await _$OfflineFirstSerdesWithTypeArgumentToRest(input,
+          provider: provider, repository: repository);
+  Future<OfflineFirstSerdesWithTypeArgument> fromSqlite(
+          Map<String, dynamic> input,
+          {provider,
+          repository}) async =>
+      await _$OfflineFirstSerdesWithTypeArgumentFromSqlite(input,
+          provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toSqlite(
+          OfflineFirstSerdesWithTypeArgument input,
+          {provider,
+          repository}) async =>
+      await _$OfflineFirstSerdesWithTypeArgumentToSqlite(input,
+          provider: provider, repository: repository);
+}
+""";
+
+class SerdesWithTypeArgument<T> extends OfflineFirstSerdes {}
+
+@ConnectOfflineFirstWithRest()
+class OfflineFirstSerdesWithTypeArgument extends OfflineFirstWithRestModel {
+  final SerdesWithTypeArgument<int> someField;
+
+  OfflineFirstSerdesWithTypeArgument(this.someField);
+}

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator_test.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator_test.dart
@@ -22,6 +22,8 @@ import 'offline_first_generator/test_only_static_members.dart' as _$onlyStaticMe
 import 'offline_first_generator/test_specify_field_name.dart' as _$specifyFieldName;
 import 'offline_first_generator/test_unrelated_association.dart' as _$unrelatedAssociation;
 import 'offline_first_generator/test_constructor_arguments.dart' as _$constructorArguments;
+import 'offline_first_generator/test_offlne_first_serdes_with_type_argument.dart'
+    as _$oflineFirstSerdesWithTypeArgument;
 
 final _generator = OfflineFirstGenerator();
 final folder = 'offline_first_generator';
@@ -80,6 +82,11 @@ void main() {
 
       test('Futures', () async {
         await generateExpectation('futures', _$futures.output);
+      });
+
+      test('OfflineFirstSerdesWithTypeArgument', () async {
+        await generateAdapterExpectation(
+            'offlne_first_serdes_with_type_argument', _$oflineFirstSerdesWithTypeArgument.output);
       });
     });
 

--- a/packages/brick_sqlite_generators/CHANGELOG.md
+++ b/packages/brick_sqlite_generators/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## Unreleased
+
+* Type arguments are stripped from fields when building the `fieldsToSqliteColumns` definition (#31)

--- a/packages/brick_sqlite_generators/lib/src/sqlite_serialize.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_serialize.dart
@@ -191,11 +191,7 @@ class SqliteSerialize<_Model extends SqliteModel> extends SqliteSerdesGenerator<
       return _finalTypeForField(checker.argType);
     }
 
-    if (checker.isMap) {
-      // remove arg types as they can't be declared in final fields
-      return "Map";
-    }
-
-    return type.getDisplayString();
+    // remove arg types as they can't be declared in final fields
+    return type.getDisplayString().replaceAll(RegExp(r'\<[,\s\w]+\>'), '');
   }
 }

--- a/packages/brick_sqlite_generators/test/sqlite_model_serdes_generator/test_field_with_type_argument.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_model_serdes_generator/test_field_with_type_argument.dart
@@ -1,0 +1,66 @@
+import 'package:brick_sqlite_abstract/annotations.dart';
+import 'package:brick_sqlite_abstract/sqlite_model.dart';
+
+final output = r"""
+// GENERATED CODE DO NOT EDIT
+// This file should NOT be version controlled and should not be manually edited.
+part of '../brick.g.dart';
+
+Future<FieldWithTypeArgument> _$FieldWithTypeArgumentFromSqlite(
+    Map<String, dynamic> data,
+    {SqliteProvider provider,
+    SqliteFirstRepository repository}) async {
+  return FieldWithTypeArgument(
+      someField:
+          data['some_field'] == null ? null : jsonDecode(data['some_field']))
+    ..primaryKey = data['_brick_id'] as int;
+}
+
+Future<Map<String, dynamic>> _$FieldWithTypeArgumentToSqlite(
+    FieldWithTypeArgument instance,
+    {SqliteProvider provider,
+    SqliteFirstRepository repository}) async {
+  return {'some_field': jsonEncode(instance.someField ?? {})};
+}
+
+/// Construct a [FieldWithTypeArgument]
+class FieldWithTypeArgumentAdapter
+    extends SqliteAdapter<FieldWithTypeArgument> {
+  FieldWithTypeArgumentAdapter();
+
+  final Map<String, Map<String, dynamic>> fieldsToSqliteColumns = {
+    'primaryKey': {
+      'name': '_brick_id',
+      'type': int,
+      'iterable': false,
+      'association': false,
+    },
+    'someField': {
+      'name': 'some_field',
+      'type': Map,
+      'iterable': false,
+      'association': false,
+    }
+  };
+  Future<int> primaryKeyByUniqueColumns(
+          FieldWithTypeArgument instance, DatabaseExecutor executor) async =>
+      null;
+  final String tableName = 'FieldWithTypeArgument';
+
+  Future<FieldWithTypeArgument> fromSqlite(Map<String, dynamic> input,
+          {provider, repository}) async =>
+      await _$FieldWithTypeArgumentFromSqlite(input,
+          provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toSqlite(FieldWithTypeArgument input,
+          {provider, repository}) async =>
+      await _$FieldWithTypeArgumentToSqlite(input,
+          provider: provider, repository: repository);
+}
+""";
+
+@SqliteSerializable()
+class FieldWithTypeArgument extends SqliteModel {
+  final Map<String, dynamic> someField;
+
+  FieldWithTypeArgument(this.someField);
+}

--- a/packages/brick_sqlite_generators/test/sqlite_model_serdes_generator_test.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_model_serdes_generator_test.dart
@@ -7,6 +7,8 @@ import 'package:source_gen/source_gen.dart';
 import 'package:brick_build/testing.dart';
 
 import 'sqlite_model_serdes_generator/test_sqlite_unique.dart' as _$sqliteUnique;
+import 'sqlite_model_serdes_generator/test_field_with_type_argument.dart'
+    as _$fieldWithTypeArgument;
 
 final _generator = TestGenerator();
 final folder = 'sqlite_model_serdes_generator';
@@ -36,6 +38,10 @@ void main() {
       test('unique', () async {
         await generateAdapterExpectation('sqlite_unique', _$sqliteUnique.output);
       });
+    });
+
+    test('FieldWithTypeArgument', () async {
+      await generateAdapterExpectation('field_with_type_argument', _$fieldWithTypeArgument.output);
     });
   });
 }


### PR DESCRIPTION
Note: this will fail tests as it relies on the master branch of `brick_sqlite_generators`. However, when `path` is set to the local package, the tests pass. The tests will pass after the branch is merged.