### PR TITLE
access unprocessed jobs in offline queue

### DIFF
--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -4,9 +4,11 @@
 * Optionally ignore Tunnel not found requests (these occur when connectivity exists but the queried endpoint is unreachable) when making repository requests
 * Adds argument to repository to reattempt requests based on the status code from the response
 * `OfflineRequestQueue#process` became a protected method
-* Added `OfflineRequestQueue#unprocessedJobs` that invokes new method `RequestSqliteCache.unprocessedJobs`.
-* Renamed `RequestSqliteCache.unprocessedRequests` to `RequestSqliteCache.latestUnprocessedRequest` as the expected query only returns one locked row at a time.
-* `RequestSqliteCache.latestUnprocessedRequest` locks _all_ unprocessed rows, not just the first one
+* Added `RequestSqliteCacheManager` to interact with the queue. This new class receives most static methods from `RequestSqliteCache`.
+* Added `OfflineRequestQueue#requestManager` to access queue via a `RequestSqliteCacheManager` instance.
+* Renamed `RequestSqliteCache.unprocessedRequests` to `RequestSqliteCacheManager.prepareNextRequestToProcess` as the expected query only returns one locked row at a time.
+* `RequestSqliteCacheManager.prepareNextRequestToProcess` locks _all_ unprocessed rows, not just the first one
+* Private member `OfflineFirstWithRestRepository#offlineRequestQueue` is now protected
 
 ## 0.0.5+1
 

--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added `OfflineRequestQueue#requestManager` to access queue via a `RequestSqliteCacheManager` instance.
 * Renamed `RequestSqliteCache.unprocessedRequests` to `RequestSqliteCacheManager.prepareNextRequestToProcess` as the expected query only returns one locked row at a time.
 * `RequestSqliteCacheManager.prepareNextRequestToProcess` locks _all_ unprocessed rows, not just the first one
+* Add ability to toggle `serialProcessing` for `OfflineRequestQueue`
 * Private member `OfflineFirstWithRestRepository#offlineRequestQueue` is now protected
 
 ## 0.0.5+1

--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -3,6 +3,10 @@
 * Remove maximumRequests configuration for the OfflineFirstQueue. One request should be processed at a time in serial
 * Optionally ignore Tunnel not found requests (these occur when connectivity exists but the queried endpoint is unreachable) when making repository requests
 * Adds argument to repository to reattempt requests based on the status code from the response
+* `OfflineRequestQueue#process` became a protected method
+* Added `OfflineRequestQueue#unprocessedJobs` that invokes new method `RequestSqliteCache.unprocessedJobs`.
+* Renamed `RequestSqliteCache.unprocessedRequests` to `RequestSqliteCache.latestUnprocessedRequest` as the expected query only returns one locked row at a time.
+* `RequestSqliteCache.latestUnprocessedRequest` locks _all_ unprocessed rows, not just the first one
 
 ## 0.0.5+1
 

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
@@ -18,16 +18,6 @@ class OfflineRequestQueue {
   /// If the queue is processing
   bool get isRunning => _timer?.isActive == true;
 
-  /// All requests not actively being processed.
-  /// /// Accessing this list can be useful for deleting a job blocking the queue.
-  Future<List<Map<String, dynamic>>> get nextJobs async =>
-      await requestManager.unprocessedJobs(whereLocked: true);
-
-  /// All requests to be retried, ordered most recent first
-  /// Accessing this list can be useful determining queue length.
-  Future<List<Map<String, dynamic>>> get unproccessedJobs async =>
-      await requestManager.unprocessedJobs();
-
   final Logger _logger;
 
   Timer _timer;
@@ -35,8 +25,14 @@ class OfflineRequestQueue {
   OfflineRequestQueue({
     @required this.client,
     Duration interval,
+
+    /// When `true`, jobs are processed one at a time in the order they were created.
+    bool processInSerial = true,
   })  : this.interval = interval ?? const Duration(seconds: 5),
-        this.requestManager = RequestSqliteCacheManager(client.databaseName),
+        this.requestManager = RequestSqliteCacheManager(
+          client.databaseName,
+          processInSerial: processInSerial,
+        ),
         _logger = Logger('OfflineRequestQueue#${client.databaseName}');
 
   /// Start the processing queue, resending requests every [interval].

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
@@ -27,11 +27,11 @@ class OfflineRequestQueue {
     Duration interval,
 
     /// When `true`, jobs are processed one at a time in the order they were created.
-    bool processInSerial = true,
+    bool serialProcessing = true,
   })  : this.interval = interval ?? const Duration(seconds: 5),
         this.requestManager = RequestSqliteCacheManager(
           client.databaseName,
-          processInSerial: processInSerial,
+          serialProcessing: serialProcessing,
         ),
         _logger = Logger('OfflineRequestQueue#${client.databaseName}');
 

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -1,0 +1,137 @@
+import 'package:path/path.dart' as p;
+import 'package:http/http.dart' as http;
+import 'package:sqflite/sqflite.dart';
+import 'package:brick_offline_first/src/offline_queue/request_sqlite_cache.dart';
+
+/// Fetch and delete [RequestSqliteCache]s.
+class RequestSqliteCacheManager {
+  final String databaseName;
+
+  RequestSqliteCacheManager(this.databaseName);
+
+  Database _db;
+  Future<Database> _getDb() async {
+    if (_db?.isOpen == true) return _db;
+    final databasesPath = await getDatabasesPath();
+    final path = p.join(databasesPath, databaseName);
+    return _db = await openDatabase(path);
+  }
+
+  /// Delete most recent job in queue. **This is a destructive action and cannot be undone**.
+  ///
+  /// returns `null` if no requests to delete;
+  /// returns `true` if the request was deleted.
+  Future<bool> deleteNextUnprocessedRequest() async {
+    final db = await _getDb();
+    final unprocessed = await unprocessedJobs(whereLocked: true);
+
+    if (unprocessed == null ||
+        unprocessed.isEmpty ||
+        unprocessed.first[HTTP_JOBS_PRIMARY_KEY_COLUMN] == null) {
+      return null;
+    }
+
+    final result = await db.delete(
+      HTTP_JOBS_TABLE_NAME,
+      where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
+      whereArgs: [unprocessed.first[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
+    );
+
+    return result > 0;
+  }
+
+  /// Discover most recent unprocessed job in database convert it back to an HTTP request.
+  /// This method also locks the row to make it idempotent to subsequent processing.
+  Future<http.Request> prepareNextRequestToProcess() async {
+    final db = await _getDb();
+    final unprocessedJobs = await db.transaction<List<Map<String, dynamic>>>((txn) async {
+      final whereUnlocked = _lockedQuery(false, selectFields: HTTP_JOBS_LOCKED_COLUMN, limit: 0);
+      final whereLocked = _lockedQuery(true, limit: 1);
+
+      // lock all unlocked requests for idempotency
+      await txn.rawUpdate([
+        'UPDATE $HTTP_JOBS_TABLE_NAME',
+        'SET $HTTP_JOBS_LOCKED_COLUMN = 1',
+        'WHERE $HTTP_JOBS_LOCKED_COLUMN IN ($whereUnlocked);',
+      ].join(' '));
+
+      return txn.rawQuery('$whereLocked;');
+    });
+
+    final jobs = unprocessedJobs.map(RequestSqliteCache.sqliteToRequest).cast<http.Request>();
+
+    if (jobs?.isEmpty == false) return jobs.first;
+
+    return null;
+  }
+
+  /// Prepare schema.
+  Future<void> migrate() async {
+    final statement = '''
+      CREATE TABLE IF NOT EXISTS `$HTTP_JOBS_TABLE_NAME` (
+        `$HTTP_JOBS_PRIMARY_KEY_COLUMN` INTEGER PRIMARY KEY AUTOINCREMENT,
+        `$HTTP_JOBS_ATTEMPTS_COLUMN` INTEGER DEFAULT 1,
+        `$HTTP_JOBS_BODY_COLUMN` TEXT,
+        `$HTTP_JOBS_ENCODING_COLUMN` TEXT,
+        `$HTTP_JOBS_HEADERS_COLUMN` TEXT,
+        `$HTTP_JOBS_LOCKED_COLUMN` INTEGER DEFAULT 0,
+        `$HTTP_JOBS_REQUEST_METHOD_COLUMN` TEXT,
+        `$HTTP_JOBS_UPDATED_AT` INTEGER DEFAULT 0,
+        `$HTTP_JOBS_URL_COLUMN` TEXT
+      );
+    ''';
+    final db = await _getDb();
+    return await db.execute(statement);
+  }
+
+  /// Returns row data for all unprocessed job in database.
+  /// Accessing this list can be useful determining queue length.
+  ///
+  /// When [whereLocked] is `true`, only jobs that are not actively being processed are returned.
+  /// Accessing this sublist can be useful for deleting a job blocking the queue.
+  /// Defaults `false`.
+  Future<List<Map<String, dynamic>>> unprocessedJobs({bool whereLocked = false}) async {
+    final db = await _getDb();
+
+    if (whereLocked) {
+      return await db.query(
+        HTTP_JOBS_TABLE_NAME,
+        distinct: true,
+        orderBy: '$HTTP_JOBS_UPDATED_AT ASC',
+        where: '$HTTP_JOBS_LOCKED_COLUMN = ?',
+        whereArgs: [1],
+      );
+    }
+
+    return await db.query(
+      HTTP_JOBS_TABLE_NAME,
+      distinct: true,
+      orderBy: '$HTTP_JOBS_UPDATED_AT ASC',
+    );
+  }
+}
+
+const HTTP_JOBS_TABLE_NAME = 'HttpJobs';
+
+const HTTP_JOBS_PRIMARY_KEY_COLUMN = 'id';
+const HTTP_JOBS_ATTEMPTS_COLUMN = 'attempts';
+const HTTP_JOBS_BODY_COLUMN = 'body';
+const HTTP_JOBS_ENCODING_COLUMN = 'encoding';
+const HTTP_JOBS_HEADERS_COLUMN = 'headers';
+const HTTP_JOBS_LOCKED_COLUMN = 'locked';
+const HTTP_JOBS_REQUEST_METHOD_COLUMN = 'request_method';
+const HTTP_JOBS_UPDATED_AT = 'updated_at';
+const HTTP_JOBS_URL_COLUMN = 'url';
+
+/// Generate SQLite query for [prepareNextRequestToProcess].
+/// When [limit] is `<= 0`, all results are returned
+String _lockedQuery(bool whereIsLocked, {String selectFields = '*', int limit = 1}) {
+  return [
+    'SELECT DISTINCT',
+    selectFields,
+    'FROM $HTTP_JOBS_TABLE_NAME',
+    'WHERE $HTTP_JOBS_LOCKED_COLUMN = ${whereIsLocked ? 1 : 0}',
+    'ORDER BY $HTTP_JOBS_UPDATED_AT ASC',
+    if (limit > 0) 'LIMIT $limit'
+  ].join(' ');
+}

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -8,7 +8,7 @@ class RequestSqliteCacheManager {
   final String databaseName;
 
   String get orderByStatement {
-    if (!processInSerial) {
+    if (!serialProcessing) {
       return '$HTTP_JOBS_UPDATED_AT ASC';
     }
 
@@ -17,13 +17,13 @@ class RequestSqliteCacheManager {
 
   /// When `true`, results are processed one at a time in the order in which they were created.
   /// Defaults `true`.
-  final bool processInSerial;
+  final bool serialProcessing;
 
   Database _db;
 
   RequestSqliteCacheManager(
     this.databaseName, {
-    this.processInSerial = true,
+    this.serialProcessing = true,
   });
 
   /// Delete job in queue. **This is a destructive action and cannot be undone**.

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -70,10 +70,10 @@ void main() {
       expect(sqliteLogs.first, contains('`updated_at` INTEGER DEFAULT 0,'));
     });
 
-    group('#unprocessedJobs', () {
+    group('#unprocessedRequests', () {
       test('default args', () async {
         final manager = RequestSqliteCacheManager('fake_db');
-        await manager.unprocessedJobs();
+        await manager.unprocessedRequests();
 
         expect(
           sqliteLogs,
@@ -83,7 +83,7 @@ void main() {
 
       test('whereLocked:true', () async {
         final manager = RequestSqliteCacheManager('fake_db');
-        await manager.unprocessedJobs(whereLocked: true);
+        await manager.unprocessedRequests(whereLocked: true);
 
         expect(
           sqliteLogs,
@@ -92,9 +92,9 @@ void main() {
       });
     });
 
-    test('#deleteNextUnprocessedRequest', () async {
+    test('#deleteUnprocessedRequest', () async {
       final manager = RequestSqliteCacheManager('fake_db');
-      final resp = await manager.deleteNextUnprocessedRequest();
+      final resp = await manager.deleteUnprocessedRequest(1);
 
       expect(
         sqliteLogs,
@@ -103,7 +103,7 @@ void main() {
           'DELETE FROM HttpJobs WHERE id = ?'
         ],
       );
-      expect(resp, 1);
+      expect(resp, isTrue);
     });
   });
 }

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -1,10 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-import 'package:logging/logging.dart';
 import '../../lib/src/offline_queue/request_sqlite_cache_manager.dart';
-
-class MockLogger extends Mock implements Logger {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:logging/logging.dart';
+import '../../lib/src/offline_queue/request_sqlite_cache_manager.dart';
+
+class MockLogger extends Mock implements Logger {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('RequestSqliteCacheManager', () {
+    var sqliteLogs = <String>[];
+
+    setUpAll(() {
+      const MethodChannel('com.tekartik.sqflite').setMockMethodCallHandler((methodCall) async {
+        if (methodCall.method == 'getDatabasesPath') {
+          return Future.value('db');
+        }
+
+        if (methodCall.method == 'openDatabase') {
+          return Future.value(null);
+        }
+
+        sqliteLogs.add(methodCall.arguments['sql']);
+        if (methodCall.method == 'query') {
+          return Future.value([
+            {
+              HTTP_JOBS_REQUEST_METHOD_COLUMN: 'PUT',
+              HTTP_JOBS_URL_COLUMN: 'http://localhost:3000/stored-query',
+              HTTP_JOBS_ATTEMPTS_COLUMN: 1,
+              HTTP_JOBS_PRIMARY_KEY_COLUMN: 1,
+            }
+          ]);
+        }
+
+        if (methodCall.method == 'update' && methodCall.arguments['sql'].startsWith('DELETE')) {
+          return 1;
+        }
+
+        return Future.value(null);
+      });
+    });
+
+    tearDown(sqliteLogs.clear);
+
+    test('#prepareNextRequestToProcess', () async {
+      final manager = RequestSqliteCacheManager('fake_db');
+      final request = await manager.prepareNextRequestToProcess();
+      expect(
+        sqliteLogs,
+        [
+          'BEGIN IMMEDIATE',
+          'UPDATE HttpJobs SET locked = 1 WHERE locked IN (SELECT DISTINCT locked FROM HttpJobs WHERE locked = 0 ORDER BY updated_at ASC);',
+          'SELECT DISTINCT * FROM HttpJobs WHERE locked = 1 ORDER BY updated_at ASC LIMIT 1;',
+          'COMMIT'
+        ],
+      );
+
+      expect(request.method, 'PUT');
+      expect(request.url.toString(), 'http://localhost:3000/stored-query');
+    });
+
+    test('#migrate', () async {
+      final manager = RequestSqliteCacheManager('fake_db');
+      await manager.migrate();
+
+      expect(sqliteLogs.first, contains('CREATE TABLE IF NOT EXISTS `HttpJobs`'));
+      expect(sqliteLogs.first, contains('`id` INTEGER PRIMARY KEY AUTOINCREMENT,'));
+      expect(sqliteLogs.first, contains('`updated_at` INTEGER DEFAULT 0,'));
+    });
+
+    group('#unprocessedJobs', () {
+      test('default args', () async {
+        final manager = RequestSqliteCacheManager('fake_db');
+        await manager.unprocessedJobs();
+
+        expect(
+          sqliteLogs,
+          ['SELECT DISTINCT * FROM HttpJobs ORDER BY updated_at ASC'],
+        );
+      });
+
+      test('whereLocked:true', () async {
+        final manager = RequestSqliteCacheManager('fake_db');
+        await manager.unprocessedJobs(whereLocked: true);
+
+        expect(
+          sqliteLogs,
+          ['SELECT DISTINCT * FROM HttpJobs WHERE locked = ? ORDER BY updated_at ASC'],
+        );
+      });
+    });
+
+    test('#deleteNextUnprocessedRequest', () async {
+      final manager = RequestSqliteCacheManager('fake_db');
+      final resp = await manager.deleteNextUnprocessedRequest();
+
+      expect(
+        sqliteLogs,
+        [
+          'SELECT DISTINCT * FROM HttpJobs WHERE locked = ? ORDER BY updated_at ASC',
+          'DELETE FROM HttpJobs WHERE id = ?'
+        ],
+      );
+      expect(resp, 1);
+    });
+  });
+}

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -127,16 +127,8 @@ void main() {
       });
     });
 
-    test('.migrate', () async {
-      await RequestSqliteCache.migrate('fake_db');
-
-      expect(sqliteLogs.first, contains('CREATE TABLE IF NOT EXISTS `HttpJobs`'));
-      expect(sqliteLogs.first, contains('`id` INTEGER PRIMARY KEY AUTOINCREMENT,'));
-      expect(sqliteLogs.first, contains('`updated_at` INTEGER DEFAULT 0,'));
-    });
-
-    test('.unprocessedRequests', () async {
-      final requests = await RequestSqliteCache.unproccessedRequests('fake_db');
+    test('.latestUnprocessedRequest', () async {
+      final request = await RequestSqliteCache.latestUnprocessedRequest('fake_db');
       expect(
         sqliteLogs,
         [
@@ -147,9 +139,16 @@ void main() {
         ],
       );
 
-      expect(requests, isNotEmpty);
-      expect(requests.first.method, 'PUT');
-      expect(requests.first.url.toString(), 'http://localhost:3000/stored-query');
+      expect(request.method, 'PUT');
+      expect(request.url.toString(), 'http://localhost:3000/stored-query');
+    });
+
+    test('.migrate', () async {
+      await RequestSqliteCache.migrate('fake_db');
+
+      expect(sqliteLogs.first, contains('CREATE TABLE IF NOT EXISTS `HttpJobs`'));
+      expect(sqliteLogs.first, contains('`id` INTEGER PRIMARY KEY AUTOINCREMENT,'));
+      expect(sqliteLogs.first, contains('`updated_at` INTEGER DEFAULT 0,'));
     });
 
     group('.toRequest', () {
@@ -189,6 +188,14 @@ void main() {
         expect(request.headers, {'Content-Type': 'application/json'});
         expect(request.body, '');
       });
+    });
+
+    test('.unprocessedJobs', () async {
+      await RequestSqliteCache.unprocessedJobs('fake_db');
+      expect(
+        sqliteLogs,
+        ['SELECT DISTINCT * FROM HttpJobs WHERE locked = ?'],
+      );
     });
   });
 }

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:mockito/mockito.dart';
 import 'package:logging/logging.dart';
 import '../../lib/src/offline_queue/request_sqlite_cache.dart';
+import '../../lib/src/offline_queue/request_sqlite_cache_manager.dart';
 
 class MockLogger extends Mock implements Logger {}
 
@@ -127,33 +128,9 @@ void main() {
       });
     });
 
-    test('.latestUnprocessedRequest', () async {
-      final request = await RequestSqliteCache.latestUnprocessedRequest('fake_db');
-      expect(
-        sqliteLogs,
-        [
-          'BEGIN IMMEDIATE',
-          'UPDATE HttpJobs SET locked = 1 WHERE locked IN (SELECT DISTINCT locked FROM HttpJobs WHERE locked = 0 ORDER BY updated_at ASC);',
-          'SELECT DISTINCT * FROM HttpJobs WHERE locked = 1 ORDER BY updated_at ASC LIMIT 1;',
-          'COMMIT'
-        ],
-      );
-
-      expect(request.method, 'PUT');
-      expect(request.url.toString(), 'http://localhost:3000/stored-query');
-    });
-
-    test('.migrate', () async {
-      await RequestSqliteCache.migrate('fake_db');
-
-      expect(sqliteLogs.first, contains('CREATE TABLE IF NOT EXISTS `HttpJobs`'));
-      expect(sqliteLogs.first, contains('`id` INTEGER PRIMARY KEY AUTOINCREMENT,'));
-      expect(sqliteLogs.first, contains('`updated_at` INTEGER DEFAULT 0,'));
-    });
-
     group('.toRequest', () {
       test('basic', () {
-        final request = RequestSqliteCache.toRequest({
+        final request = RequestSqliteCache.sqliteToRequest({
           HTTP_JOBS_REQUEST_METHOD_COLUMN: 'POST',
           HTTP_JOBS_URL_COLUMN: 'http://localhost:3000',
           HTTP_JOBS_BODY_COLUMN: 'POST body'
@@ -165,7 +142,7 @@ void main() {
       });
 
       test('missing headers', () {
-        final request = RequestSqliteCache.toRequest({
+        final request = RequestSqliteCache.sqliteToRequest({
           HTTP_JOBS_REQUEST_METHOD_COLUMN: 'GET',
           HTTP_JOBS_URL_COLUMN: 'http://localhost:3000'
         });
@@ -177,7 +154,7 @@ void main() {
       });
 
       test('with headers', () {
-        final request = RequestSqliteCache.toRequest({
+        final request = RequestSqliteCache.sqliteToRequest({
           HTTP_JOBS_REQUEST_METHOD_COLUMN: 'GET',
           HTTP_JOBS_URL_COLUMN: 'http://localhost:3000',
           HTTP_JOBS_HEADERS_COLUMN: '{"Content-Type": "application/json"}'
@@ -188,14 +165,6 @@ void main() {
         expect(request.headers, {'Content-Type': 'application/json'});
         expect(request.body, '');
       });
-    });
-
-    test('.unprocessedJobs', () async {
-      await RequestSqliteCache.unprocessedJobs('fake_db');
-      expect(
-        sqliteLogs,
-        ['SELECT DISTINCT * FROM HttpJobs WHERE locked = ?'],
-      );
     });
   });
 }

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -133,7 +133,7 @@ void main() {
         sqliteLogs,
         [
           'BEGIN IMMEDIATE',
-          'UPDATE HttpJobs SET locked = 1 WHERE locked IN (SELECT DISTINCT locked FROM HttpJobs WHERE locked = 0 ORDER BY updated_at ASC LIMIT 1);',
+          'UPDATE HttpJobs SET locked = 1 WHERE locked IN (SELECT DISTINCT locked FROM HttpJobs WHERE locked = 0 ORDER BY updated_at ASC);',
           'SELECT DISTINCT * FROM HttpJobs WHERE locked = 1 ORDER BY updated_at ASC LIMIT 1;',
           'COMMIT'
         ],


### PR DESCRIPTION
* `OfflineRequestQueue#process` became a protected method
* Added `RequestSqliteCacheManager` to interact with the queue. This new class receives most static methods from `RequestSqliteCache`.
* Added `OfflineRequestQueue#requestManager` to access queue via a `RequestSqliteCacheManager` instance.
* Renamed `RequestSqliteCache.unprocessedRequests` to `RequestSqliteCacheManager.prepareNextRequestToProcess` as the expected query only returns one locked row at a time.
* `RequestSqliteCacheManager.prepareNextRequestToProcess` locks _all_ unprocessed rows, not just the first one
* Private member `OfflineFirstWithRestRepository#offlineRequestQueue` is now protected