### PR TITLE
fix rest serialization, `null` in rest upsert and delete

### DIFF
--- a/packages/brick_offline_first_with_rest_build/CHANGELOG.md
+++ b/packages/brick_offline_first_with_rest_build/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## Unreleased
+
+* Fix a a JSON encode error. `.map` returns a `MappedListIterable` which `jsonEncode` cannot parse. It can parse `List<dynamic>`.

--- a/packages/brick_offline_first_with_rest_build/lib/src/offline_first_rest_generators.dart
+++ b/packages/brick_offline_first_with_rest_build/lib/src/offline_first_rest_generators.dart
@@ -34,14 +34,14 @@ class _OfflineFirstRestSerialize extends RestSerialize<OfflineFirstWithRestModel
         final awaited = checker.isArgTypeAFuture ? 'async => (await s)' : '=> s';
         final pair = offlineFirstAnnotation.where.entries.first;
         final instanceWithField = wrappedInFuture ? '(await $fieldValue)' : fieldValue;
-        return '$instanceWithField?.map((s) $awaited.${pair.key})';
+        return '$instanceWithField?.map((s) $awaited.${pair.key})?.toList()';
       }
 
       // Iterable<OfflineFirstSerdes>
       if (argTypeChecker.hasSerdes) {
         final _hasSerializer = hasSerializer(checker.argType);
         if (_hasSerializer) {
-          return '$fieldValue?.map((${checker.argType.getDisplayString()} c) => c?.$serializeMethod())';
+          return '$fieldValue?.map((${checker.argType.getDisplayString()} c) => c?.$serializeMethod())?.toList()';
         }
       }
     }

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_custom_offline_first_serdes.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_custom_offline_first_serdes.dart
@@ -20,7 +20,7 @@ Future<Map<String, dynamic>> _$CustomOfflineFirstSerdesToRest(
     OfflineFirstRepository repository}) async {
   return {
     'string': instance.string?.toRest(),
-    'strings': instance.strings?.map((Serializable c) => c?.toRest())
+    'strings': instance.strings?.map((Serializable c) => c?.toRest())?.toList()
   };
 }
 

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offline_first_where.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offline_first_where.dart
@@ -74,7 +74,7 @@ Future<Map<String, dynamic>> _$OfflineFirstWhereToRest(
   return {
     'assoc': (await instance.assoc)?.id,
     'loaded_assoc': "Going to REST",
-    'loaded_assocs': instance.loadedAssocs?.map((s) => s.id),
+    'loaded_assocs': instance.loadedAssocs?.map((s) => s.id)?.toList(),
     'multi_lookup_custom_generator': "As REST"
   };
 }

--- a/packages/brick_rest/CHANGELOG.md
+++ b/packages/brick_rest/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* When `url` is `null` in `RestProvider#upsert` and `RestProvider#delete`, return `null` and do not attempt to perform the action
+
 ## 0.0.5
 
 * Carry rename from `Query#params` to `Query#providerArgs` from brick_core

--- a/packages/brick_rest/lib/rest.dart
+++ b/packages/brick_rest/lib/rest.dart
@@ -44,6 +44,8 @@ class RestProvider implements Provider<RestModel> {
   Future<http.Response> delete<_Model extends RestModel>(instance, {query, repository}) async {
     final url = urlForModel<_Model>(query, instance);
     _logger.fine('DELETE $url');
+    if (url == null) return null;
+
     final resp = await client.delete(url, headers: headersForQuery(query));
 
     _logger.finest('caller=delete url=$url statusCode=${resp?.statusCode} body=${resp?.body}');
@@ -105,6 +107,8 @@ class RestProvider implements Provider<RestModel> {
     final body = await adapter.toRest(instance, provider: this, repository: repository);
 
     final url = urlForModel<_Model>(query, instance);
+    if (url == null) return null;
+
     final resp = await _sendUpsertResponse(url, body, query, adapter.toKey);
 
     _logger.finest('caller=upsert url=$url statusCode=${resp?.statusCode} body=${resp?.body}');

--- a/packages/brick_rest/lib/rest.dart
+++ b/packages/brick_rest/lib/rest.dart
@@ -43,8 +43,8 @@ class RestProvider implements Provider<RestModel> {
   @override
   Future<http.Response> delete<_Model extends RestModel>(instance, {query, repository}) async {
     final url = urlForModel<_Model>(query, instance);
-    _logger.fine('DELETE $url');
     if (url == null) return null;
+    _logger.fine('DELETE $url');
 
     final resp = await client.delete(url, headers: headersForQuery(query));
 

--- a/packages/brick_rest_generators/CHANGELOG.md
+++ b/packages/brick_rest_generators/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## Unreleased
+
+* Fix a a JSON encode error in REST serialization. `.map` returns a `MappedListIterable` which `jsonEncode` cannot parse. It can parse `List<dynamic>`.

--- a/packages/brick_rest_generators/lib/src/rest_serialize.dart
+++ b/packages/brick_rest_generators/lib/src/rest_serialize.dart
@@ -42,9 +42,9 @@ class RestSerialize<_Model extends RestModel> extends RestSerdesGenerator<_Model
       // Iterable<enum>
       if (argTypeChecker.isEnum) {
         if (fieldAnnotation.enumAsString) {
-          return "$fieldValue?.map((e) => e.toString().split('.').last)";
+          return "$fieldValue?.map((e) => e.toString().split('.').last)?.toList()";
         } else {
-          return '$fieldValue?.map((e) => ${checker.argType.getDisplayString()}.values.indexOf(e))';
+          return '$fieldValue?.map((e) => ${checker.argType.getDisplayString()}.values.indexOf(e))?.toList()';
         }
       }
 

--- a/packages/brick_rest_generators/test/rest_model_serdes_generator/test_enum_as_string.dart
+++ b/packages/brick_rest_generators/test/rest_model_serdes_generator/test_enum_as_string.dart
@@ -19,7 +19,7 @@ Future<Map<String, dynamic>> _$EnumAsStringToRest(EnumAsString instance,
     {RestProvider provider, RestFirstRepository repository}) async {
   return {
     'hat': instance.hat?.toString()?.split('.')?.last,
-    'hats': instance.hats?.map((e) => e.toString().split('.').last)
+    'hats': instance.hats?.map((e) => e.toString().split('.').last)?.toList()
   };
 }
 ''';


### PR DESCRIPTION
* Fix a a JSON encode error. `.map` returns a `MappedListIterable` which `jsonEncode` cannot parse. It can parse `List<dynamic>`.
* When `url` is `null` in `RestProvider#upsert` and `RestProvider#delete`, return `null` and do not attempt to perform the action
