### PR TITLE
detect index commands in generator

### DIFF
--- a/packages/brick_offline_first/example/lib/app/adapters/horse_adapter.g.dart
+++ b/packages/brick_offline_first/example/lib/app/adapters/horse_adapter.g.dart
@@ -7,8 +7,7 @@ Future<Horse> _$HorseFromRest(Map<String, dynamic> data,
   return Horse(
       name: data['name'] as String,
       mounties: await Future.wait<Mounty>(data['mounties']
-              ?.map((d) => MountyAdapter()
-                  .fromRest(d, provider: provider, repository: repository))
+              ?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))
               ?.toList()
               ?.cast<Future<Mounty>>() ??
           []));
@@ -19,14 +18,12 @@ Future<Map<String, dynamic>> _$HorseToRest(Horse instance,
   return {
     'name': instance.name,
     'mounties': await Future.wait<Map<String, dynamic>>(
-        instance.mounties?.map((s) => MountyAdapter().toRest(s))?.toList() ??
-            [])
+        instance.mounties?.map((s) => MountyAdapter().toRest(s))?.toList() ?? [])
   };
 }
 
 Future<Horse> _$HorseFromSqlite(Map<String, dynamic> data,
-    {SqliteProvider provider,
-    OfflineFirstWithRestRepository repository}) async {
+    {SqliteProvider provider, OfflineFirstWithRestRepository repository}) async {
   return Horse(
       name: data['name'] == null ? null : data['name'] as String,
       mounties: (await provider?.rawQuery(
@@ -45,8 +42,7 @@ Future<Horse> _$HorseFromSqlite(Map<String, dynamic> data,
 }
 
 Future<Map<String, dynamic>> _$HorseToSqlite(Horse instance,
-    {SqliteProvider provider,
-    OfflineFirstWithRestRepository repository}) async {
+    {SqliteProvider provider, OfflineFirstWithRestRepository repository}) async {
   return {'name': instance.name};
 }
 
@@ -77,33 +73,25 @@ class HorseAdapter extends OfflineFirstWithRestAdapter<Horse> {
       'association': true,
     }
   };
-  Future<int> primaryKeyByUniqueColumns(
-          Horse instance, DatabaseExecutor executor) async =>
-      null;
+  Future<int> primaryKeyByUniqueColumns(Horse instance, DatabaseExecutor executor) async => null;
   final String tableName = 'Horse';
   Future<void> afterSave(instance, {provider, repository}) async {
     if (instance.primaryKey != null) {
       await Future.wait<int>(instance.mounties?.map((s) async {
-        final id = s?.primaryKey ??
-            await provider?.upsert<Mounty>(s, repository: repository);
+        final id = s?.primaryKey ?? await provider?.upsert<Mounty>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_Horse_mounties` (`Horse_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_Horse_mounties` (`Horse_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
   }
 
-  Future<Horse> fromRest(Map<String, dynamic> input,
-          {provider, repository}) async =>
+  Future<Horse> fromRest(Map<String, dynamic> input, {provider, repository}) async =>
       await _$HorseFromRest(input, provider: provider, repository: repository);
-  Future<Map<String, dynamic>> toRest(Horse input,
-          {provider, repository}) async =>
+  Future<Map<String, dynamic>> toRest(Horse input, {provider, repository}) async =>
       await _$HorseToRest(input, provider: provider, repository: repository);
-  Future<Horse> fromSqlite(Map<String, dynamic> input,
-          {provider, repository}) async =>
-      await _$HorseFromSqlite(input,
-          provider: provider, repository: repository);
-  Future<Map<String, dynamic>> toSqlite(Horse input,
-          {provider, repository}) async =>
+  Future<Horse> fromSqlite(Map<String, dynamic> input, {provider, repository}) async =>
+      await _$HorseFromSqlite(input, provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toSqlite(Horse input, {provider, repository}) async =>
       await _$HorseToSqlite(input, provider: provider, repository: repository);
 }

--- a/packages/brick_offline_first/example/lib/app/adapters/kitchen_sink_adapter.g.dart
+++ b/packages/brick_offline_first/example/lib/app/adapters/kitchen_sink_adapter.g.dart
@@ -9,36 +9,40 @@ Future<KitchenSink> _$KitchenSinkFromRest(Map<String, dynamic> data,
       anyInt: data['any_int'] as int,
       anyDouble: data['any_double'] as double,
       anyNum: data['any_num'] as num,
-      anyDateTime: data['any_date_time'] == null
-          ? null
-          : DateTime.tryParse(data['any_date_time'] as String),
+      anyDateTime:
+          data['any_date_time'] == null ? null : DateTime.tryParse(data['any_date_time'] as String),
       anyBool: data['any_bool'] as bool,
       anyMap: data['any_map'],
-      enumFromIndex: data['enum_from_index'] is int
-          ? AnyEnum.values[data['enum_from_index'] as int]
-          : null,
+      enumFromIndex:
+          data['enum_from_index'] is int ? AnyEnum.values[data['enum_from_index'] as int] : null,
       anyList: data['any_list']?.toList()?.cast<int>() ?? <int>[],
       anySet: data['any_set']?.toSet()?.cast<int>() ?? <int>{},
-      offlineFirstModel: await MountyAdapter().fromRest(data['offline_first_model'],
-          provider: provider, repository: repository),
-      listOfflineFirstModel: await Future.wait<Mounty>(
-          data['list_offline_first_model']?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))?.toList()?.cast<Future<Mounty>>() ??
-              []),
+      offlineFirstModel: await MountyAdapter()
+          .fromRest(data['offline_first_model'], provider: provider, repository: repository),
+      listOfflineFirstModel: await Future.wait<Mounty>(data['list_offline_first_model']
+              ?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))
+              ?.toList()
+              ?.cast<Future<Mounty>>() ??
+          []),
       setOfflineFirstModel:
           (await Future.wait<Mounty>(data['set_offline_first_model']?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))?.toSet()?.cast<Future<Mounty>>() ?? []))
               ?.toSet(),
-      futureOfflineFirstModel: MountyAdapter().fromRest(
-          data['future_offline_first_model'],
-          provider: provider,
-          repository: repository),
+      futureOfflineFirstModel: MountyAdapter()
+          .fromRest(data['future_offline_first_model'], provider: provider, repository: repository),
       futureListOfflineFirstModel: data['future_list_offline_first_model']
-          ?.map((d) =>
-              MountyAdapter().fromRest(d, provider: provider, repository: repository))
+          ?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))
           ?.toList()
           ?.cast<Future<Mounty>>(),
-      futureSetOfflineFirstModel: (data['future_set_offline_first_model']?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))?.toSet()?.cast<Future<Mounty>>())?.toSet(),
+      futureSetOfflineFirstModel: (data['future_set_offline_first_model']
+              ?.map((d) => MountyAdapter().fromRest(d, provider: provider, repository: repository))
+              ?.toSet()
+              ?.cast<Future<Mounty>>())
+          ?.toSet(),
       offlineFirstSerdes: Hat.fromRest(data['offline_first_serdes']),
-      listOfflineFirstSerdes: data['list_offline_first_serdes'].map((c) => Hat.fromRest(c as Map<String, dynamic>))?.toList()?.cast<Hat>(),
+      listOfflineFirstSerdes: data['list_offline_first_serdes']
+          .map((c) => Hat.fromRest(c as Map<String, dynamic>))
+          ?.toList()
+          ?.cast<Hat>(),
       setOfflineFirstSerdes: data['set_offline_first_serdes'].map((c) => Hat.fromRest(c as Map<String, dynamic>))?.toSet()?.cast<Hat>(),
       restAnnotationName: data['restAnnotationOtherName'] as String,
       restAnnotationDefaultValue: data['rest_annotation_default_value'] as String ?? "a default value",
@@ -67,35 +71,27 @@ Future<Map<String, dynamic>> _$KitchenSinkToRest(KitchenSink instance,
     'any_date_time': instance.anyDateTime?.toIso8601String(),
     'any_bool': instance.anyBool,
     'any_map': instance.anyMap,
-    'enum_from_index': instance.enumFromIndex != null
-        ? AnyEnum.values.indexOf(instance.enumFromIndex)
-        : null,
+    'enum_from_index':
+        instance.enumFromIndex != null ? AnyEnum.values.indexOf(instance.enumFromIndex) : null,
     'any_list': instance.anyList,
     'any_set': instance.anySet,
-    'offline_first_model':
-        await MountyAdapter().toRest(instance.offlineFirstModel),
-    'list_offline_first_model': await Future.wait<Map<String, dynamic>>(instance
-            .listOfflineFirstModel
-            ?.map((s) => MountyAdapter().toRest(s))
-            ?.toList() ??
-        []),
-    'set_offline_first_model': await Future.wait<Map<String, dynamic>>(instance
-            .setOfflineFirstModel
-            ?.map((s) => MountyAdapter().toRest(s))
-            ?.toList() ??
-        []),
+    'offline_first_model': await MountyAdapter().toRest(instance.offlineFirstModel),
+    'list_offline_first_model': await Future.wait<Map<String, dynamic>>(
+        instance.listOfflineFirstModel?.map((s) => MountyAdapter().toRest(s))?.toList() ?? []),
+    'set_offline_first_model': await Future.wait<Map<String, dynamic>>(
+        instance.setOfflineFirstModel?.map((s) => MountyAdapter().toRest(s))?.toList() ?? []),
     'future_offline_first_model':
         await MountyAdapter().toRest((await instance.futureOfflineFirstModel)),
-    'future_list_offline_first_model': await Future.wait<Map<String, dynamic>>(
-        instance.futureListOfflineFirstModel
-                ?.map((s) async => MountyAdapter().toRest((await s)))
-                ?.toList() ??
-            []),
-    'future_set_offline_first_model': await Future.wait<Map<String, dynamic>>(
-        instance.futureSetOfflineFirstModel
-                ?.map((s) async => MountyAdapter().toRest((await s)))
-                ?.toList() ??
-            []),
+    'future_list_offline_first_model': await Future.wait<Map<String, dynamic>>(instance
+            .futureListOfflineFirstModel
+            ?.map((s) async => MountyAdapter().toRest((await s)))
+            ?.toList() ??
+        []),
+    'future_set_offline_first_model': await Future.wait<Map<String, dynamic>>(instance
+            .futureSetOfflineFirstModel
+            ?.map((s) async => MountyAdapter().toRest((await s)))
+            ?.toList() ??
+        []),
     'offline_first_serdes': instance.offlineFirstSerdes?.toRest(),
     'list_offline_first_serdes':
         instance.listOfflineFirstSerdes?.map((Hat c) => c?.toRest())?.toList(),
@@ -106,8 +102,7 @@ Future<Map<String, dynamic>> _$KitchenSinkToRest(KitchenSink instance,
     'rest_annotation_nullable': instance.restAnnotationNullable,
     'rest_annotation_ignore_from': instance.restAnnotationIgnoreFrom,
     'rest_annotation_from_generator': instance.restAnnotationFromGenerator,
-    'rest_annotation_to_generator':
-        instance.restAnnotationToGenerator.toString(),
+    'rest_annotation_to_generator': instance.restAnnotationToGenerator.toString(),
     'enum_from_string': instance.enumFromString?.toString()?.split('.')?.last,
     'sqlite_annotation_nullable': instance.sqliteAnnotationNullable,
     'sqlite_annotation_default_value': instance.sqliteAnnotationDefaultValue,
@@ -121,14 +116,11 @@ Future<Map<String, dynamic>> _$KitchenSinkToRest(KitchenSink instance,
 }
 
 Future<KitchenSink> _$KitchenSinkFromSqlite(Map<String, dynamic> data,
-    {SqliteProvider provider,
-    OfflineFirstWithRestRepository repository}) async {
+    {SqliteProvider provider, OfflineFirstWithRestRepository repository}) async {
   return KitchenSink(
-      anyString:
-          data['any_string'] == null ? null : data['any_string'] as String,
+      anyString: data['any_string'] == null ? null : data['any_string'] as String,
       anyInt: data['any_int'] == null ? null : data['any_int'] as int,
-      anyDouble:
-          data['any_double'] == null ? null : data['any_double'] as double,
+      anyDouble: data['any_double'] == null ? null : data['any_double'] as double,
       anyNum: data['any_num'] == null ? null : data['any_num'] as num,
       anyDateTime: data['any_date_time'] == null
           ? null
@@ -139,28 +131,22 @@ Future<KitchenSink> _$KitchenSinkFromSqlite(Map<String, dynamic> data,
       anyMap: data['any_map'] == null ? null : jsonDecode(data['any_map']),
       enumFromIndex: data['enum_from_index'] == null
           ? null
-          : (data['enum_from_index'] > -1
-              ? AnyEnum.values[data['enum_from_index'] as int]
-              : null),
-      anyList: data['any_list'] == null
-          ? null
-          : jsonDecode(data['any_list'])?.toList()?.cast<int>(),
-      anySet: data['any_set'] == null
-          ? null
-          : jsonDecode(data['any_set'])?.toSet()?.cast<int>(),
+          : (data['enum_from_index'] > -1 ? AnyEnum.values[data['enum_from_index'] as int] : null),
+      anyList:
+          data['any_list'] == null ? null : jsonDecode(data['any_list'])?.toList()?.cast<int>(),
+      anySet: data['any_set'] == null ? null : jsonDecode(data['any_set'])?.toSet()?.cast<int>(),
       offlineFirstModel: data['offline_first_model_Mounty_brick_id'] == null
           ? null
           : (data['offline_first_model_Mounty_brick_id'] > -1
               ? (await repository?.getAssociation<Mounty>(
-                  Query.where('primaryKey',
-                      data['offline_first_model_Mounty_brick_id'] as int,
+                  Query.where('primaryKey', data['offline_first_model_Mounty_brick_id'] as int,
                       limit1: true),
                 ))
                   ?.first
               : null),
       listOfflineFirstModel: (await provider
-              ?.rawQuery('SELECT `Mounty_brick_id` FROM `_brick_KitchenSink_list_offline_first_model` WHERE KitchenSink_brick_id = ?',
-                  [data['_brick_id'] as int])?.then((results) {
+              ?.rawQuery('SELECT `Mounty_brick_id` FROM `_brick_KitchenSink_list_offline_first_model` WHERE KitchenSink_brick_id = ?', [data['_brick_id'] as int])?.then(
+                  (results) {
         final ids = results.map((r) => (r ?? {})['Mounty_brick_id']);
         return Future.wait<Mounty>(ids.map((primaryKey) => repository
             ?.getAssociation<Mounty>(
@@ -182,36 +168,40 @@ Future<KitchenSink> _$KitchenSinkFromSqlite(Map<String, dynamic> data,
       }))
           .toSet()
           .cast<Mounty>(),
-      futureOfflineFirstModel:
-          data['future_offline_first_model_Mounty_brick_id'] == null
-              ? null
-              : (data['future_offline_first_model_Mounty_brick_id'] > -1
-                  ? repository
-                      ?.getAssociation<Mounty>(
-                        Query.where(
-                            'primaryKey',
-                            data['future_offline_first_model_Mounty_brick_id']
-                                as int,
-                            limit1: true),
-                      )
-                      ?.then((r) => (r?.isEmpty ?? true) ? null : r.first)
-                  : null),
-      futureListOfflineFirstModel: await provider
-          ?.rawQuery('SELECT `Mounty_brick_id` FROM `_brick_KitchenSink_future_list_offline_first_model` WHERE KitchenSink_brick_id = ?', [data['_brick_id'] as int])?.then((results) {
+      futureOfflineFirstModel: data['future_offline_first_model_Mounty_brick_id'] == null
+          ? null
+          : (data['future_offline_first_model_Mounty_brick_id'] > -1
+              ? repository
+                  ?.getAssociation<Mounty>(
+                    Query.where(
+                        'primaryKey', data['future_offline_first_model_Mounty_brick_id'] as int,
+                        limit1: true),
+                  )
+                  ?.then((r) => (r?.isEmpty ?? true) ? null : r.first)
+              : null),
+      futureListOfflineFirstModel: await provider?.rawQuery(
+          'SELECT `Mounty_brick_id` FROM `_brick_KitchenSink_future_list_offline_first_model` WHERE KitchenSink_brick_id = ?',
+          [data['_brick_id'] as int])?.then((results) {
         final ids = results.map((r) => (r ?? {})['Mounty_brick_id']);
-        return ids.map((primaryKey) => repository
-            ?.getAssociation<Mounty>(
-              Query.where('primaryKey', primaryKey, limit1: true),
-            )
-            ?.then((r) => (r?.isEmpty ?? true) ? null : r.first)).toList().cast<Future<Mounty>>();
+        return ids
+            .map((primaryKey) => repository
+                ?.getAssociation<Mounty>(
+                  Query.where('primaryKey', primaryKey, limit1: true),
+                )
+                ?.then((r) => (r?.isEmpty ?? true) ? null : r.first))
+            .toList()
+            .cast<Future<Mounty>>();
       }),
       futureSetOfflineFirstModel: await provider?.rawQuery('SELECT `Mounty_brick_id` FROM `_brick_KitchenSink_future_set_offline_first_model` WHERE KitchenSink_brick_id = ?', [data['_brick_id'] as int])?.then((results) {
         final ids = results.map((r) => (r ?? {})['Mounty_brick_id']);
-        return ids.map((primaryKey) => repository
-            ?.getAssociation<Mounty>(
-              Query.where('primaryKey', primaryKey, limit1: true),
-            )
-            ?.then((r) => (r?.isEmpty ?? true) ? null : r.first)).toSet().cast<Future<Mounty>>();
+        return ids
+            .map((primaryKey) => repository
+                ?.getAssociation<Mounty>(
+                  Query.where('primaryKey', primaryKey, limit1: true),
+                )
+                ?.then((r) => (r?.isEmpty ?? true) ? null : r.first))
+            .toSet()
+            .cast<Future<Mounty>>();
       }),
       offlineFirstSerdes: data['offline_first_serdes'] == null ? null : Hat.fromSqlite(data['offline_first_serdes'] as String),
       listOfflineFirstSerdes: data['list_offline_first_serdes'] == null ? null : jsonDecode(data['list_offline_first_serdes']).map((c) => Hat.fromSqlite(c as String))?.toList()?.cast<Hat>(),
@@ -235,8 +225,7 @@ Future<KitchenSink> _$KitchenSinkFromSqlite(Map<String, dynamic> data,
           ? null
           : (data['offline_first_where_Mounty_brick_id'] > -1
               ? (await repository?.getAssociation<Mounty>(
-                  Query.where('primaryKey',
-                      data['offline_first_where_Mounty_brick_id'] as int,
+                  Query.where('primaryKey', data['offline_first_where_Mounty_brick_id'] as int,
                       limit1: true),
                 ))
                   ?.first
@@ -245,8 +234,7 @@ Future<KitchenSink> _$KitchenSinkFromSqlite(Map<String, dynamic> data,
 }
 
 Future<Map<String, dynamic>> _$KitchenSinkToSqlite(KitchenSink instance,
-    {SqliteProvider provider,
-    OfflineFirstWithRestRepository repository}) async {
+    {SqliteProvider provider, OfflineFirstWithRestRepository repository}) async {
   return {
     'any_string': instance.anyString,
     'any_int': instance.anyInt,
@@ -258,30 +246,22 @@ Future<Map<String, dynamic>> _$KitchenSinkToSqlite(KitchenSink instance,
     'enum_from_index': AnyEnum.values.indexOf(instance.enumFromIndex),
     'any_list': jsonEncode(instance.anyList ?? []),
     'any_set': jsonEncode(instance.anySet?.toList() ?? []),
-    'offline_first_model_Mounty_brick_id':
-        instance.offlineFirstModel?.primaryKey ??
-            await provider?.upsert<Mounty>(instance.offlineFirstModel,
-                repository: repository),
-    'set_offline_first_model':
-        jsonEncode(instance.setOfflineFirstModel?.toList() ?? []),
+    'offline_first_model_Mounty_brick_id': instance.offlineFirstModel?.primaryKey ??
+        await provider?.upsert<Mounty>(instance.offlineFirstModel, repository: repository),
+    'set_offline_first_model': jsonEncode(instance.setOfflineFirstModel?.toList() ?? []),
     'future_offline_first_model_Mounty_brick_id':
         (await instance.futureOfflineFirstModel)?.primaryKey ??
-            await provider?.upsert<Mounty>(
-                (await instance.futureOfflineFirstModel),
+            await provider?.upsert<Mounty>((await instance.futureOfflineFirstModel),
                 repository: repository),
     'future_set_offline_first_model':
         jsonEncode(instance.futureSetOfflineFirstModel?.toList() ?? []),
     'offline_first_serdes': instance.offlineFirstSerdes?.toSqlite(),
-    'list_offline_first_serdes': jsonEncode(instance.listOfflineFirstSerdes
-            ?.map((Hat c) => c?.toSqlite())
-            ?.toList()
-            ?.cast<String>() ??
-        []),
-    'set_offline_first_serdes': jsonEncode(instance.setOfflineFirstSerdes
-            ?.map((Hat c) => c?.toSqlite())
-            ?.toList()
-            ?.cast<String>() ??
-        []),
+    'list_offline_first_serdes': jsonEncode(
+        instance.listOfflineFirstSerdes?.map((Hat c) => c?.toSqlite())?.toList()?.cast<String>() ??
+            []),
+    'set_offline_first_serdes': jsonEncode(
+        instance.setOfflineFirstSerdes?.map((Hat c) => c?.toSqlite())?.toList()?.cast<String>() ??
+            []),
     'rest_annotation_name': instance.restAnnotationName,
     'rest_annotation_default_value': instance.restAnnotationDefaultValue,
     'rest_annotation_nullable': instance.restAnnotationNullable,
@@ -294,14 +274,11 @@ Future<Map<String, dynamic>> _$KitchenSinkToSqlite(KitchenSink instance,
     'sqlite_annotation_nullable': instance.sqliteAnnotationNullable,
     'sqlite_annotation_default_value': instance.sqliteAnnotationDefaultValue,
     'sqlite_annotation_from_generator': instance.sqliteAnnotationFromGenerator,
-    'sqlite_annotation_to_generator':
-        instance.sqliteAnnotationToGenerator.toString(),
+    'sqlite_annotation_to_generator': instance.sqliteAnnotationToGenerator.toString(),
     'sqlite_annotation_unique': instance.sqliteAnnotationUnique,
     'custom column name': instance.sqliteAnnotationName,
-    'offline_first_where_Mounty_brick_id':
-        instance.offlineFirstWhere?.primaryKey ??
-            await provider?.upsert<Mounty>(instance.offlineFirstWhere,
-                repository: repository)
+    'offline_first_where_Mounty_brick_id': instance.offlineFirstWhere?.primaryKey ??
+        await provider?.upsert<Mounty>(instance.offlineFirstWhere, repository: repository)
   };
 }
 
@@ -530,15 +507,14 @@ class KitchenSinkAdapter extends OfflineFirstWithRestAdapter<KitchenSink> {
       'association': true,
     }
   };
-  Future<int> primaryKeyByUniqueColumns(
-      KitchenSink instance, DatabaseExecutor executor) async {
+  Future<int> primaryKeyByUniqueColumns(KitchenSink instance, DatabaseExecutor executor) async {
     final results = await executor.rawQuery('''
         SELECT * FROM `KitchenSink` WHERE sqlite_annotation_unique = ? LIMIT 1''',
         [instance.sqliteAnnotationUnique]);
 
     // SQFlite returns [{}] when no results are found
-    if (results?.isEmpty == true ||
-        (results?.length == 1 && results?.first?.isEmpty == true)) return null;
+    if (results?.isEmpty == true || (results?.length == 1 && results?.first?.isEmpty == true))
+      return null;
 
     return results.first['_brick_id'];
   }
@@ -547,61 +523,49 @@ class KitchenSinkAdapter extends OfflineFirstWithRestAdapter<KitchenSink> {
   Future<void> afterSave(instance, {provider, repository}) async {
     if (instance.primaryKey != null) {
       await Future.wait<int>(instance.listOfflineFirstModel?.map((s) async {
-        final id = s?.primaryKey ??
-            await provider?.upsert<Mounty>(s, repository: repository);
+        final id = s?.primaryKey ?? await provider?.upsert<Mounty>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_KitchenSink_list_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_KitchenSink_list_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
 
     if (instance.primaryKey != null) {
       await Future.wait<int>(instance.setOfflineFirstModel?.map((s) async {
-        final id = s?.primaryKey ??
-            await provider?.upsert<Mounty>(s, repository: repository);
+        final id = s?.primaryKey ?? await provider?.upsert<Mounty>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_KitchenSink_set_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_KitchenSink_set_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
 
     if (instance.primaryKey != null) {
-      await Future.wait<int>(
-          instance.futureListOfflineFirstModel?.map((s) async {
+      await Future.wait<int>(instance.futureListOfflineFirstModel?.map((s) async {
         final id = (await s)?.primaryKey ??
             await provider?.upsert<Mounty>((await s), repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_KitchenSink_future_list_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_KitchenSink_future_list_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
 
     if (instance.primaryKey != null) {
-      await Future.wait<int>(
-          instance.futureSetOfflineFirstModel?.map((s) async {
+      await Future.wait<int>(instance.futureSetOfflineFirstModel?.map((s) async {
         final id = (await s)?.primaryKey ??
             await provider?.upsert<Mounty>((await s), repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_KitchenSink_future_set_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_KitchenSink_future_set_offline_first_model` (`KitchenSink_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
   }
 
-  Future<KitchenSink> fromRest(Map<String, dynamic> input,
-          {provider, repository}) async =>
-      await _$KitchenSinkFromRest(input,
-          provider: provider, repository: repository);
-  Future<Map<String, dynamic>> toRest(KitchenSink input,
-          {provider, repository}) async =>
-      await _$KitchenSinkToRest(input,
-          provider: provider, repository: repository);
-  Future<KitchenSink> fromSqlite(Map<String, dynamic> input,
-          {provider, repository}) async =>
-      await _$KitchenSinkFromSqlite(input,
-          provider: provider, repository: repository);
-  Future<Map<String, dynamic>> toSqlite(KitchenSink input,
-          {provider, repository}) async =>
-      await _$KitchenSinkToSqlite(input,
-          provider: provider, repository: repository);
+  Future<KitchenSink> fromRest(Map<String, dynamic> input, {provider, repository}) async =>
+      await _$KitchenSinkFromRest(input, provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toRest(KitchenSink input, {provider, repository}) async =>
+      await _$KitchenSinkToRest(input, provider: provider, repository: repository);
+  Future<KitchenSink> fromSqlite(Map<String, dynamic> input, {provider, repository}) async =>
+      await _$KitchenSinkFromSqlite(input, provider: provider, repository: repository);
+  Future<Map<String, dynamic>> toSqlite(KitchenSink input, {provider, repository}) async =>
+      await _$KitchenSinkToSqlite(input, provider: provider, repository: repository);
 }

--- a/packages/brick_offline_first/pubspec.yaml
+++ b/packages/brick_offline_first/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   brick_offline_first_abstract: ^0.0.7
   brick_rest: ^0.0.7
   brick_sqlite: ^0.1.0+1
-  brick_sqlite_abstract: ^0.0.7+1
+  brick_sqlite_abstract: ^0.0.8+1
   dart_style: ^1.2.4
   http: ^0.12.0
   logging: ^0.11.3+2

--- a/packages/brick_offline_first/test/offline_first/__adapters_models__.dart
+++ b/packages/brick_offline_first/test/offline_first/__adapters_models__.dart
@@ -161,7 +161,7 @@ class HorseAdapter extends OfflineFirstWithRestAdapter<Horse> {
       await Future.wait<int>(instance.mounties?.map((s) async {
         final id = s?.primaryKey ?? await provider?.upsert<Mounty>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_Horse_mounties` (`Horse_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_Horse_mounties` (`Horse_brick_id`, `Mounty_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }

--- a/packages/brick_offline_first_abstract/pubspec.yaml
+++ b/packages/brick_offline_first_abstract/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   meta: ^1.1.6
   brick_core: ^0.0.6
   brick_rest: ^0.0.5
-  brick_sqlite_abstract: ^0.0.7+1
+  brick_sqlite_abstract: ^0.0.8+1

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_futures.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_futures.dart
@@ -170,7 +170,7 @@ class FuturesAdapter extends OfflineFirstAdapter<Futures> {
         final id = (await s)?.primaryKey ??
             await provider?.upsert<Assoc>((await s), repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_Futures_future_assocs` (`l_Futures_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_Futures_future_assocs` (`l_Futures_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offline_first_where.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_offline_first_where.dart
@@ -175,7 +175,7 @@ class OfflineFirstWhereAdapter extends OfflineFirstAdapter<OfflineFirstWhere> {
         final id = (await s)?.primaryKey ??
             await provider?.upsert<Assoc>((await s), repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_OfflineFirstWhere_assocs` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_OfflineFirstWhere_assocs` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
@@ -185,7 +185,7 @@ class OfflineFirstWhereAdapter extends OfflineFirstAdapter<OfflineFirstWhere> {
         final id = s?.primaryKey ??
             await provider?.upsert<Assoc>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_OfflineFirstWhere_loaded_assocs` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_OfflineFirstWhere_loaded_assocs` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }
@@ -196,7 +196,7 @@ class OfflineFirstWhereAdapter extends OfflineFirstAdapter<OfflineFirstWhere> {
         final id = (await s)?.primaryKey ??
             await provider?.upsert<Assoc>((await s), repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_OfflineFirstWhere_multi_lookup_custom_generator` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_OfflineFirstWhere_multi_lookup_custom_generator` (`l_OfflineFirstWhere_brick_id`, `f_Assoc_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_one_to_many_association.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_one_to_many_association.dart
@@ -104,7 +104,7 @@ class OneToManyAssociationAdapter
         final id = s?.primaryKey ??
             await provider?.upsert<SqliteAssoc>(s, repository: repository);
         return await provider?.rawInsert(
-            'INSERT OR REPLACE INTO `_brick_OneToManyAssociation_assoc` (`l_OneToManyAssociation_brick_id`, `f_SqliteAssoc_brick_id`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `_brick_OneToManyAssociation_assoc` (`l_OneToManyAssociation_brick_id`, `f_SqliteAssoc_brick_id`) VALUES (?, ?)',
             [instance.primaryKey, id]);
       }));
     }

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
@@ -15,19 +15,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('SqliteAssoc',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          ])),
+          }),
       SchemaTable('OneToOneAssocation',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('assoc_SqliteAssoc_brick_id', int,
@@ -40,8 +40,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 @ConnectOfflineFirstWithRest()

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
@@ -25,7 +25,8 @@ final schema = Schema(0,
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          }),
+          },
+          indices: <SchemaIndex>{}),
       SchemaTable('OneToOneAssocation',
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
@@ -40,7 +41,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
@@ -25,7 +25,8 @@ final schema = Schema(0,
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          }),
+          },
+          indices: <SchemaIndex>{}),
       SchemaTable('_brick_OneToOneAssocation_assocs',
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
@@ -50,7 +51,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
@@ -15,19 +15,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('SqliteAssoc',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          ])),
+          }),
       SchemaTable('_brick_OneToOneAssocation_assocs',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('l_OneToOneAssocation_brick_id', int,
@@ -40,9 +40,9 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: true,
                 onDeleteSetDefault: false)
-          ])),
+          }),
       SchemaTable('OneToOneAssocation',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('assoc_SqliteAssoc_brick_id', int,
@@ -50,8 +50,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 @ConnectOfflineFirstWithRest()

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -323,7 +323,7 @@ class SqliteProvider implements Provider<SqliteModel> {
             'SELECT DISTINCT ${InsertTable.PRIMARY_KEY_COLUMN} FROM `$foreignTableName` WHERE ${InsertTable.PRIMARY_KEY_COLUMN} = $id LIMIT 1');
         if (hasAssociation.isNotEmpty) {
           await db.rawInsert(
-            'INSERT OR REPLACE INTO `${InsertForeignKey.joinsTableName(columnName, localTableName: localTableName)}` (`${InsertForeignKey.joinsTableLocalColumnName(localTableName)}`, `${InsertForeignKey.joinsTableForeignColumnName(foreignTableName)}`) VALUES (?, ?)',
+            'INSERT OR IGNORE INTO `${InsertForeignKey.joinsTableName(columnName, localTableName: localTableName)}` (`${InsertForeignKey.joinsTableLocalColumnName(localTableName)}`, `${InsertForeignKey.joinsTableForeignColumnName(foreignTableName)}`) VALUES (?, ?)',
             [result[InsertTable.PRIMARY_KEY_COLUMN], id],
           );
         }

--- a/packages/brick_sqlite/pubspec.yaml
+++ b/packages/brick_sqlite/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   brick_core: ^0.0.6
-  brick_sqlite_abstract: ^0.0.7+4
+  brick_sqlite_abstract: ^0.0.8
   logging: ^0.11.3+2
   meta: ^1.1.6
   path: ^1.6.3

--- a/packages/brick_sqlite/pubspec.yaml
+++ b/packages/brick_sqlite/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   brick_core: ^0.0.6
-  brick_sqlite_abstract: ^0.0.8
+  brick_sqlite_abstract: ^0.0.8+1
   logging: ^0.11.3+2
   meta: ^1.1.6
   path: ^1.6.3

--- a/packages/brick_sqlite/test/sqlite_test.dart
+++ b/packages/brick_sqlite/test/sqlite_test.dart
@@ -91,7 +91,7 @@ void main() {
         await provider.rawInsert('INSERT INTO `$foreignTableName` (name) VALUES ("Bowler")');
         await provider.rawInsert('INSERT INTO `$foreignTableName` (name) VALUES ("Big")');
         await provider.rawInsert(
-            'INSERT OR REPLACE INTO `$localTableName` ($columnName) VALUES (?)', ['[1,2,3]']);
+            'INSERT OR IGNORE INTO `$localTableName` ($columnName) VALUES (?)', ['[1,2,3]']);
         for (var command in table) await provider.rawExecute(command.statement);
 
         await provider.migrateFromStringToJoinsTable(columnName, localTableName, foreignTableName);

--- a/packages/brick_sqlite_abstract/CHANGELOG.md
+++ b/packages/brick_sqlite_abstract/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add a `DropIndex` command to revert `CreateIndex` changes
+
 ## 0.0.8
 
 * When joins tables are created, add a unique index by both columns to ensure no duplicates are inserted. Prior applications will need to manually specify `CreateIndex` in a custom migration for existing joins tables. When new joins tables are generated in migrations, `CreateIndex` will also be generated.

--- a/packages/brick_sqlite_abstract/CHANGELOG.md
+++ b/packages/brick_sqlite_abstract/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
-* When joins tables are created, add a unique index by both columns to ensure no duplicates are inserted
+## 0.0.8
+
+* When joins tables are created, add a unique index by both columns to ensure no duplicates are inserted. Prior applications will need to manually specify `CreateIndex` in a custom migration for existing joins tables. When new joins tables are generated in migrations, `CreateIndex` will also be generated.
 
 ## 0.0.7+4
 

--- a/packages/brick_sqlite_abstract/CHANGELOG.md
+++ b/packages/brick_sqlite_abstract/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Unreleased
 
+## 0.0.8+1
+
 * Add a `DropIndex` command to revert `CreateIndex` changes
+* Detect `CreateIndex` changes and generate a migration
 
 ## 0.0.8
 

--- a/packages/brick_sqlite_abstract/lib/src/db/migration_commands.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/migration_commands.dart
@@ -4,6 +4,7 @@ export 'package:brick_sqlite_abstract/src/db/migration_commands/migration_comman
 
 export 'package:brick_sqlite_abstract/src/db/migration_commands/create_index.dart';
 export 'package:brick_sqlite_abstract/src/db/migration_commands/drop_column.dart';
+export 'package:brick_sqlite_abstract/src/db/migration_commands/drop_index.dart';
 export 'package:brick_sqlite_abstract/src/db/migration_commands/drop_table.dart';
 export 'package:brick_sqlite_abstract/src/db/migration_commands/insert_column.dart';
 export 'package:brick_sqlite_abstract/src/db/migration_commands/insert_foreign_key.dart';

--- a/packages/brick_sqlite_abstract/lib/src/db/migration_commands/create_index.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/migration_commands/create_index.dart
@@ -1,7 +1,8 @@
+import 'package:brick_sqlite_abstract/src/db/migration_commands/drop_index.dart';
 import 'package:meta/meta.dart';
 import 'migration_command.dart';
 
-/// Drop table from DB if it exists
+/// Create an index on a table if it doesn't already exists
 class CreateIndex extends MigrationCommand {
   final List<String> columns;
 
@@ -33,4 +34,7 @@ class CreateIndex extends MigrationCommand {
   @override
   String get forGenerator =>
       "CreateIndex(columns: [${columns.map((c) => "'$c'").join(', ')}], onTable: '$onTable', unique: $unique)";
+
+  @override
+  MigrationCommand get down => DropIndex(name);
 }

--- a/packages/brick_sqlite_abstract/lib/src/db/migration_commands/create_index.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/migration_commands/create_index.dart
@@ -16,10 +16,7 @@ class CreateIndex extends MigrationCommand {
     this.unique = false,
   });
 
-  String get name {
-    final columnNames = columns.join('_');
-    return '${columnNames}_index';
-  }
+  String get name => generateName(columns, onTable);
 
   @override
   String get statement {
@@ -37,4 +34,9 @@ class CreateIndex extends MigrationCommand {
 
   @override
   MigrationCommand get down => DropIndex(name);
+
+  static String generateName(List<String> columns, String onTable) {
+    final columnNames = columns.join('_');
+    return ['index', onTable, 'on', columnNames].join('_');
+  }
 }

--- a/packages/brick_sqlite_abstract/lib/src/db/migration_commands/drop_index.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/migration_commands/drop_index.dart
@@ -1,0 +1,14 @@
+import 'migration_command.dart';
+
+/// Drop index from DB if it exists
+class DropIndex extends MigrationCommand {
+  final String name;
+
+  const DropIndex(this.name);
+
+  @override
+  String get statement => 'DROP INDEX IF EXISTS $name';
+
+  @override
+  String get forGenerator => "DropIndex('$name')";
+}

--- a/packages/brick_sqlite_abstract/lib/src/db/migration_commands/insert_foreign_key.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/migration_commands/insert_foreign_key.dart
@@ -80,14 +80,9 @@ class InsertForeignKey extends MigrationCommand {
   /// The downside of this pattern is the inevitable data duplication for such many-to-many
   /// relationships and the inability to query relationships without declaring them on
   /// parent/child models.
-  //
-  // If this method is changed, the index creation in [isAJoinsTable] needs to be updated
   static String joinsTableName(String columnName, {String localTableName}) {
     return ['_brick', localTableName, columnName].join('_');
   }
-
-  /// Determine if a tableName is a joins table
-  static bool isAJoinsTable(String tableName) => tableName.startsWith('_brick');
 
   /// In the rare case of a many-to-many association of the same model, the columns must be prefixed.
   /// For example, `final List<Friend> friends` on class `Friend`.

--- a/packages/brick_sqlite_abstract/lib/src/db/schema.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema.dart
@@ -12,6 +12,7 @@ import 'schema/schema_table.dart';
 export 'package:brick_sqlite_abstract/src/db/schema/schema_table.dart';
 export 'package:brick_sqlite_abstract/src/db/schema/schema_column.dart';
 export 'package:brick_sqlite_abstract/src/db/schema/schema_difference.dart';
+export 'package:brick_sqlite_abstract/src/db/schema/schema_index.dart';
 
 class Schema {
   /// The last version successfully migrated to SQLite.

--- a/packages/brick_sqlite_abstract/lib/src/db/schema.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema.dart
@@ -124,6 +124,13 @@ class Schema {
       ));
     } else if (command is CreateIndex) {
       final table = findTable(command.onTable);
+      final tableColumnNames = table.columns.map((c) => c.name);
+      command.columns.forEach((c) {
+        if (!tableColumnNames.contains(c)) {
+          throw StateError(
+              '${command.onTable} does not contain column $c specified by CreateIndex');
+        }
+      });
       table.indices.add(SchemaIndex(
         columns: command.columns,
         tableName: command.onTable,

--- a/packages/brick_sqlite_abstract/lib/src/db/schema.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema.dart
@@ -128,6 +128,12 @@ class Schema {
         tableName: command.onTable,
         unique: command.unique,
       ));
+    } else if (command is DropIndex) {
+      final table = tables.firstWhere(
+        (s) => s.indices.map((i) => i.name).contains(command.name),
+        orElse: () => throw StateError('Index ${command.name} must be inserted first'),
+      );
+      table.indices.removeWhere((i) => i.name == command.name);
     } else {
       throw FallThroughError();
     }

--- a/packages/brick_sqlite_abstract/lib/src/db/schema.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema.dart
@@ -1,5 +1,6 @@
 // Heavily, heavily inspired by [Aqueduct](https://github.com/stablekernel/aqueduct/blob/master/aqueduct/lib/src/db/schema/schema_builder.dart)
 // Unfortunately, some key differences such as inability to use mirrors and the sqlite vs postgres capabilities make DIY a more palatable option than retrofitting
+import 'package:brick_sqlite_abstract/src/db/schema/schema_index.dart';
 import 'package:meta/meta.dart' show required, visibleForTesting;
 
 import 'migration.dart';
@@ -120,6 +121,13 @@ class Schema {
         onDeleteCascade: command.onDeleteCascade,
         onDeleteSetDefault: command.onDeleteSetDefault,
       ));
+    } else if (command is CreateIndex) {
+      final table = findTable(command.onTable);
+      table.indices.add(SchemaIndex(
+        columns: command.columns,
+        tableName: command.onTable,
+        unique: command.unique,
+      ));
     } else {
       throw FallThroughError();
     }
@@ -136,9 +144,9 @@ class Schema {
     return '''Schema(
 \t$version,
 \tgeneratorVersion: $generatorVersion,
-\ttables: Set<SchemaTable>.from([
+\ttables: <SchemaTable>{
 \t\t$tableString
-\t])
+\t}
 )'''
         .replaceAll('\t', '  ');
   }

--- a/packages/brick_sqlite_abstract/lib/src/db/schema.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema.dart
@@ -130,8 +130,11 @@ class Schema {
         unique: command.unique,
       ));
     } else if (command is DropIndex) {
+      tables.forEach((t) => t.indices.forEach((i) => i.tableName == t.name));
       final table = tables.firstWhere(
-        (s) => s.indices.map((i) => i.name).contains(command.name),
+        (s) => s.indices
+            .map((i) => CreateIndex.generateName(i.columns, i.tableName))
+            .contains(command.name),
         orElse: () => throw StateError('Index ${command.name} must be inserted first'),
       );
       table.indices.removeWhere((i) => i.name == command.name);

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
@@ -1,4 +1,3 @@
-import 'package:brick_sqlite_abstract/src/db/migration_commands/create_index.dart';
 import 'package:brick_sqlite_abstract/src/db/schema/schema_index.dart';
 
 import '../migration_commands.dart';
@@ -59,17 +58,10 @@ class SchemaDifference {
         .expand((s) => s)
         .cast<MigrationCommand>();
 
-    final indexes =
-        insertedTables.where((table) => InsertForeignKey.isAJoinsTable(table.name)).map((table) {
-      final columns = addedColumns
-          .where((column) => column.tableName == table.name)
-          .map((column) => column.name)
-          .toList()
-          .cast<String>();
-      return CreateIndex(columns: columns, onTable: table.name, unique: true);
-    });
+    final addedIndices = createdIndices.map((c) => c.toCommand());
+    final removedIndices = droppedIndices.map((c) => c.toCommand());
 
-    return [removedTables, removedColumns, added, indexes]
+    return [removedTables, removedColumns, added, addedIndices, removedIndices]
         .expand((l) => l)
         .toList()
         .cast<MigrationCommand>();

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
@@ -1,4 +1,5 @@
 import 'package:brick_sqlite_abstract/src/db/migration_commands/create_index.dart';
+import 'package:brick_sqlite_abstract/src/db/schema/schema_index.dart';
 
 import '../migration_commands.dart';
 import '../schema.dart';
@@ -16,6 +17,10 @@ class SchemaDifference {
 
   Set<SchemaTable> get insertedTables => newSchema.tables.difference(oldSchema.tables);
 
+  Set<SchemaIndex> get droppedIndices => _compareIndices(oldSchema, newSchema);
+
+  Set<SchemaIndex> get createdIndices => _compareIndices(newSchema, oldSchema);
+
   Set<SchemaColumn> get droppedColumns => _compareColumns(oldSchema, newSchema);
 
   Set<SchemaColumn> get insertedColumns => _compareColumns(newSchema, oldSchema);
@@ -23,6 +28,8 @@ class SchemaDifference {
   bool get hasDifference =>
       droppedTables.isNotEmpty ||
       insertedTables.isNotEmpty ||
+      droppedIndices.isNotEmpty ||
+      createdIndices.isNotEmpty ||
       droppedColumns.isNotEmpty ||
       insertedColumns.isNotEmpty;
 
@@ -90,6 +97,23 @@ class SchemaDifference {
       fromColumns.forEach((c) => c.tableName = fromTable.name);
       toColumns.forEach((c) => c.tableName = fromTable.name);
       return fromColumns.difference(toColumns);
+    }
+
+    return from.tables.map(differenceFromTable).expand((t) => t).toSet();
+  }
+
+  Set<SchemaIndex> _compareIndices(Schema from, Schema to) {
+    Set<SchemaIndex> differenceFromTable(SchemaTable fromTable) {
+      final toIndices =
+          to.tables.firstWhere((t) => t.name == fromTable.name, orElse: () => null)?.indices ??
+              <SchemaIndex>{};
+
+      final fromIndices = <SchemaIndex>{}..addAll(fromTable.indices);
+
+      // From and to tables should have identical names via `lookup`
+      fromIndices.forEach((c) => c.tableName = fromTable.name);
+      toIndices.forEach((c) => c.tableName = fromTable.name);
+      return fromIndices.difference(toIndices);
     }
 
     return from.tables.map(differenceFromTable).expand((t) => t).toSet();

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_index.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_index.dart
@@ -1,0 +1,35 @@
+import '../migration_commands.dart';
+import 'schema_base.dart';
+
+class SchemaIndex extends BaseSchemaObject {
+  final List<String> columns;
+
+  String tableName;
+
+  final bool unique;
+
+  SchemaIndex({
+    this.columns,
+    this.tableName,
+    this.unique,
+  });
+
+  @override
+  String get forGenerator =>
+      "SchemaIndex(columns: [${columns.map((c) => "'$c'").join(', ')}], tableName: '$tableName', unique: $unique)";
+
+  @override
+  MigrationCommand toCommand() => CreateIndex(columns: columns, onTable: tableName, unique: unique);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SchemaIndex &&
+          name == other?.name &&
+          // tableNames don't compare nicely since they're non-final
+          (tableName ?? '').compareTo(other?.tableName ?? '') == 0 &&
+          forGenerator == other?.forGenerator;
+
+  @override
+  int get hashCode => name.hashCode ^ forGenerator.hashCode;
+}

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_index.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_index.dart
@@ -16,7 +16,7 @@ class SchemaIndex extends BaseSchemaObject {
 
   @override
   String get forGenerator =>
-      "SchemaIndex(columns: [${columns.map((c) => "'$c'").join(', ')}], tableName: '$tableName', unique: $unique)";
+      "SchemaIndex(columns: [${columns.map((c) => "'$c'").join(', ')}], unique: $unique)";
 
   @override
   MigrationCommand toCommand() => CreateIndex(columns: columns, onTable: tableName, unique: unique);

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
@@ -17,10 +17,9 @@ class SchemaTable extends BaseSchemaObject {
 
   SchemaTable(
     this.name, {
-    Set<SchemaColumn> columns,
-    Set<SchemaIndex> indices,
-  })  : columns = columns ?? <SchemaColumn>{},
-        indices = indices ?? <SchemaIndex>{};
+    this.columns = const <SchemaColumn>{},
+    this.indices = const <SchemaIndex>{},
+  });
 
   @override
   String get forGenerator {

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
@@ -17,9 +17,10 @@ class SchemaTable extends BaseSchemaObject {
 
   SchemaTable(
     this.name, {
-    this.columns = const <SchemaColumn>{},
-    this.indices = const <SchemaIndex>{},
-  });
+    Set<SchemaColumn> columns,
+    Set<SchemaIndex> indices,
+  })  : columns = columns ?? <SchemaColumn>{},
+        indices = indices ?? <SchemaIndex>{};
 
   @override
   String get forGenerator {

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_table.dart
@@ -4,6 +4,7 @@
 import '../migration_commands.dart';
 import 'schema_base.dart';
 import 'schema_column.dart';
+import 'schema_index.dart';
 
 /// Describes a table object managed by SQLite
 class SchemaTable extends BaseSchemaObject {
@@ -12,19 +13,27 @@ class SchemaTable extends BaseSchemaObject {
 
   Set<SchemaColumn> columns;
 
+  Set<SchemaIndex> indices;
+
   SchemaTable(
     this.name, {
     Set<SchemaColumn> columns,
-  }) : columns = columns ?? <SchemaColumn>{};
+    Set<SchemaIndex> indices,
+  })  : columns = columns ?? <SchemaColumn>{},
+        indices = indices ?? <SchemaIndex>{};
 
   @override
   String get forGenerator {
     final columnsStringified = columns.map((c) => c.forGenerator).join(',\n\t\t');
+    final indicesStringified = indices.map((c) => c.forGenerator).join(',\n\t\t');
     return '''SchemaTable(
 \t'$name',
-\tcolumns: Set.from([
+\tcolumns: <SchemaColumn>{
 \t\t$columnsStringified
-\t])
+\t},
+\tindices: <SchemaIndex>{
+\t\t$indicesStringified  
+\t}
 )''';
   }
 

--- a/packages/brick_sqlite_abstract/pubspec.yaml
+++ b/packages/brick_sqlite_abstract/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_sqlite_a
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.0.8
+version: 0.0.8+1
 
 environment:
   sdk: '>=2.6.0 <3.0.0'

--- a/packages/brick_sqlite_abstract/pubspec.yaml
+++ b/packages/brick_sqlite_abstract/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_sqlite_a
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.0.7+4
+version: 0.0.8
 
 environment:
   sdk: '>=2.6.0 <3.0.0'

--- a/packages/brick_sqlite_abstract/test/db/__mocks__.dart
+++ b/packages/brick_sqlite_abstract/test/db/__mocks__.dart
@@ -81,3 +81,23 @@ class MigrationInsertForeignKey extends Migration {
           down: const [],
         );
 }
+
+class MigrationCreateIndex extends Migration {
+  const MigrationCreateIndex()
+      : super(
+          version: 7,
+          up: const [
+            CreateIndex(columns: ['_brick_id'], onTable: 'demo', unique: true)
+          ],
+          down: const [DropIndex('index_demo_on__brick_id')],
+        );
+}
+
+class MigrationDropIndex extends Migration {
+  const MigrationDropIndex()
+      : super(
+          version: 8,
+          up: const [DropIndex('index_demo_on__brick_id')],
+          down: const [],
+        );
+}

--- a/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
@@ -32,6 +32,11 @@ void main() {
         expect(mUnique.forGenerator,
             "CreateIndex(columns: ['f_Local_brick_id', 'l_Field_brick_id'], onTable: '_brick_Local_field', unique: true)");
       });
+
+      test('.generateName', () {
+        expect(CreateIndex.generateName(['user_id', 'friend_id', 'account_id'], 'Person'),
+            'index_Person_on_user_id_friend_id_account_id');
+      });
     });
 
     group('DropColumn', () {

--- a/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
@@ -21,9 +21,9 @@ void main() {
 
       test('#statement', () {
         expect(m.statement,
-            'CREATE INDEX IF NOT EXISTS f_Local_brick_id_l_Field_brick_id_index on _brick_Local_field(`f_Local_brick_id`, `l_Field_brick_id`)');
+            'CREATE INDEX IF NOT EXISTS index__brick_Local_field_on_f_Local_brick_id_l_Field_brick_id on _brick_Local_field(`f_Local_brick_id`, `l_Field_brick_id`)');
         expect(mUnique.statement,
-            'CREATE UNIQUE INDEX IF NOT EXISTS f_Local_brick_id_l_Field_brick_id_index on _brick_Local_field(`f_Local_brick_id`, `l_Field_brick_id`)');
+            'CREATE UNIQUE INDEX IF NOT EXISTS index__brick_Local_field_on_f_Local_brick_id_l_Field_brick_id on _brick_Local_field(`f_Local_brick_id`, `l_Field_brick_id`)');
       });
 
       test('#forGenerator', () {

--- a/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
@@ -46,6 +46,18 @@ void main() {
       });
     });
 
+    group('DropIndex', () {
+      const m = DropIndex('name');
+
+      test('#statement', () {
+        expect(m.statement, 'DROP INDEX IF EXISTS name');
+      });
+
+      test('#forGenerator', () {
+        expect(m.forGenerator, "DropIndex('name')");
+      });
+    });
+
     group('DropTable', () {
       const m = DropTable('demo');
 

--- a/packages/brick_sqlite_abstract/test/db/schema_difference_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_difference_test.dart
@@ -260,6 +260,9 @@ void main() {
                   onDeleteSetDefault: true,
                 ),
               ]),
+              indices: <SchemaIndex>{
+                SchemaIndex(columns: ['l_People_brick_id', 'f_Friend_brick_id'], unique: true)
+              },
             ),
           },
         );

--- a/packages/brick_sqlite_abstract/test/db/schema_difference_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_difference_test.dart
@@ -23,8 +23,8 @@ void main() {
     });
 
     test('#droppedTables', () {
-      final oldSchema = Schema(0, tables: Set.from([table]));
-      final newSchema = Schema(1, tables: Set.from([]));
+      final oldSchema = Schema(0, tables: {table});
+      final newSchema = Schema(1, tables: {});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.droppedTables, contains(table));
@@ -33,8 +33,8 @@ void main() {
     });
 
     test('#insertedTables', () {
-      final oldSchema = Schema(0, tables: Set.from([]));
-      final newSchema = Schema(1, tables: Set.from([table]));
+      final oldSchema = Schema(0, tables: {});
+      final newSchema = Schema(1, tables: {table});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.insertedTables, hasLength(1));
@@ -46,8 +46,8 @@ void main() {
     group('columns', () {
       test('#droppedColumns', () {
         table.columns.add(column);
-        final oldSchema = Schema(0, tables: Set.from([table]));
-        final newSchema = Schema(1, tables: Set.from([tableNoColumn]));
+        final oldSchema = Schema(0, tables: {table});
+        final newSchema = Schema(1, tables: {tableNoColumn});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(diff.droppedColumns, contains(column));
@@ -57,8 +57,8 @@ void main() {
 
       test('#insertedColumns', () {
         table.columns.add(column);
-        final oldSchema = Schema(0, tables: Set.from([tableNoColumn]));
-        final newSchema = Schema(1, tables: Set.from([table]));
+        final oldSchema = Schema(0, tables: {tableNoColumn});
+        final newSchema = Schema(1, tables: {table});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(diff.insertedColumns, contains(column));
@@ -69,7 +69,7 @@ void main() {
       test('#insertedColumns across multiple tables', () {
         final schema = Schema(
           2,
-          tables: Set<SchemaTable>.from([
+          tables: <SchemaTable>{
             SchemaTable(
               'demo',
               columns: Set<SchemaColumn>.from([
@@ -86,7 +86,7 @@ void main() {
                 SchemaColumn('email', String)
               ]),
             ),
-          ]),
+          },
         );
 
         expect(
@@ -108,8 +108,8 @@ void main() {
       );
       table.columns.add(foreignKeyColumn);
 
-      final oldSchema = Schema(0, tables: Set.from([tableNoColumn]));
-      final newSchema = Schema(1, tables: Set.from([table]));
+      final oldSchema = Schema(0, tables: {tableNoColumn});
+      final newSchema = Schema(1, tables: {table});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.insertedColumns, contains(foreignKeyColumn));
@@ -141,8 +141,8 @@ void main() {
       );
       newTable.columns.add(foreignKeyColumnWithOnDeleteCascade);
 
-      final oldSchema = Schema(0, tables: Set.from([table]));
-      final newSchema = Schema(1, tables: Set.from([newTable]));
+      final oldSchema = Schema(0, tables: {table});
+      final newSchema = Schema(1, tables: {newTable});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.insertedColumns, contains(foreignKeyColumnWithOnDeleteCascade));
@@ -174,8 +174,8 @@ void main() {
       );
       newTable.columns.add(foreignKeyColumnWithOnDeleteSetDefault);
 
-      final oldSchema = Schema(0, tables: Set.from([table]));
-      final newSchema = Schema(1, tables: Set.from([newTable]));
+      final oldSchema = Schema(0, tables: {table});
+      final newSchema = Schema(1, tables: {newTable});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.insertedColumns, contains(foreignKeyColumnWithOnDeleteSetDefault));
@@ -185,8 +185,8 @@ void main() {
 
     group('#toMigrationCommands', () {
       test('#insertedTables', () {
-        final oldSchema = Schema(0, tables: Set.from([]));
-        final newSchema = Schema(1, tables: Set.from([table]));
+        final oldSchema = Schema(0, tables: {});
+        final newSchema = Schema(1, tables: {table});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(
@@ -201,8 +201,8 @@ void main() {
 
       test('#insertedColumns', () {
         table.columns.add(column);
-        final oldSchema = Schema(0, tables: Set.from([]));
-        final newSchema = Schema(1, tables: Set.from([table]));
+        final oldSchema = Schema(0, tables: {});
+        final newSchema = Schema(1, tables: {table});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(
@@ -216,8 +216,8 @@ void main() {
       });
 
       test('#droppedColumns', () {
-        final oldSchema = Schema(0, tables: Set.from([table]));
-        final newSchema = Schema(1, tables: Set.from([tableNoColumn]));
+        final oldSchema = Schema(0, tables: {table});
+        final newSchema = Schema(1, tables: {tableNoColumn});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(diff.toMigrationCommands(), [DropColumn(column.name, onTable: column.tableName)]);
@@ -226,8 +226,8 @@ void main() {
       });
 
       test('#droppedTables', () {
-        final oldSchema = Schema(0, tables: Set.from([table]));
-        final newSchema = Schema(1, tables: Set.from([]));
+        final oldSchema = Schema(0, tables: {table});
+        final newSchema = Schema(1, tables: {});
 
         final diff = SchemaDifference(oldSchema, newSchema);
         expect(diff.toMigrationCommands(), [DropTable('demo')]);
@@ -236,7 +236,7 @@ void main() {
       });
 
       test('joins table indexes', () {
-        final oldSchema = Schema(0, tables: Set.from([]));
+        final oldSchema = Schema(0, tables: {});
         final newSchema = Schema(
           1,
           tables: {
@@ -284,8 +284,8 @@ void main() {
     });
 
     test('#forGenerator', () {
-      final oldSchema = Schema(0, tables: Set.from([]));
-      final newSchema = Schema(1, tables: Set.from([table]));
+      final oldSchema = Schema(0, tables: {});
+      final newSchema = Schema(1, tables: {table});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(
@@ -296,8 +296,8 @@ void main() {
     });
 
     test('#hasDifference between equal schemas', () {
-      final oldSchema = Schema(0, tables: Set.from([table]));
-      final newSchema = Schema(1, tables: Set.from([table]));
+      final oldSchema = Schema(0, tables: {table});
+      final newSchema = Schema(1, tables: {table});
 
       final diff = SchemaDifference(oldSchema, newSchema);
       expect(diff.hasDifference, isFalse);

--- a/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
@@ -6,27 +6,27 @@ void main() {
     test('#forGenerator', () {
       final table = SchemaTable(
         'users',
-        columns: Set.from([
+        columns: <SchemaColumn>{
           SchemaColumn('first_name', String),
           SchemaColumn('_brick_id', int, autoincrement: true, isPrimaryKey: true),
           SchemaColumn('amount', int, defaultValue: 0),
           SchemaColumn('last_name', String, nullable: false),
-        ]),
+        },
       );
 
       expect(table.forGenerator, '''SchemaTable(
 \t'users',
-\tcolumns: Set.from([
+\tcolumns: <SchemaColumn>{
 \t\tSchemaColumn('first_name', String),
 \t\tSchemaColumn('_brick_id', int, autoincrement: true, isPrimaryKey: true),
 \t\tSchemaColumn('amount', int, defaultValue: 0),
 \t\tSchemaColumn('last_name', String, nullable: false)
-\t])
+\t}
 )''');
     });
 
     group('#toCommand', () {
-      final table = SchemaTable('users', columns: Set.from([]));
+      final table = SchemaTable('users', columns: <SchemaColumn>{});
 
       test('shouldDrop:false', () {
         expect(table.toCommand(shouldDrop: false), const InsertTable('users'));
@@ -41,15 +41,15 @@ void main() {
       test('same name, different columns', () {
         final table1 = SchemaTable(
           'users',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('first_name', String),
-          ]),
+          },
         );
         final table2 = SchemaTable(
           'users',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('last_name', String),
-          ]),
+          },
         );
 
         expect(table1, equals(table2));
@@ -58,15 +58,15 @@ void main() {
       test('different name, same columns', () {
         final table1 = SchemaTable(
           'users',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('first_name', String),
-          ]),
+          },
         );
         final table2 = SchemaTable(
           'people',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('first_name', String),
-          ]),
+          },
         );
 
         expect(table1, isNot(table2));

--- a/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
@@ -21,7 +21,8 @@ void main() {
 \t\tSchemaColumn('_brick_id', int, autoincrement: true, isPrimaryKey: true),
 \t\tSchemaColumn('amount', int, defaultValue: 0),
 \t\tSchemaColumn('last_name', String, nullable: false)
-\t}
+\t},
+\tindices: <SchemaIndex>{}
 )''');
     });
 

--- a/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
@@ -22,7 +22,9 @@ void main() {
 \t\tSchemaColumn('amount', int, defaultValue: 0),
 \t\tSchemaColumn('last_name', String, nullable: false)
 \t},
-\tindices: <SchemaIndex>{}
+\tindices: <SchemaIndex>{
+\t\t
+\t}
 )''');
     });
 

--- a/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_objects_test.dart
@@ -23,7 +23,7 @@ void main() {
 \t\tSchemaColumn('last_name', String, nullable: false)
 \t},
 \tindices: <SchemaIndex>{
-\t\t
+\t\t  
 \t}
 )''');
     });

--- a/packages/brick_sqlite_abstract/test/db/schema_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_test.dart
@@ -9,6 +9,8 @@ void main() {
       const insertColumn = MigrationInsertColumn();
       const renameColumn = MigrationRenameColumn();
       const insertForeignKey = MigrationInsertForeignKey();
+      const createIndex = MigrationCreateIndex();
+      const dropIndex = MigrationDropIndex();
 
       group('InsertTable', () {
         test('calls', () {
@@ -170,6 +172,52 @@ void main() {
         });
       });
 
+      group('CreateIndex', () {
+        test('runs', () {
+          final schema = Schema(
+            7,
+            tables: <SchemaTable>{
+              SchemaTable(
+                'demo',
+                columns: <SchemaColumn>{
+                  SchemaColumn('_brick_id', int,
+                      autoincrement: true, nullable: false, isPrimaryKey: true),
+                },
+                indices: <SchemaIndex>{
+                  SchemaIndex(columns: ['_brick_id'], unique: true),
+                },
+              )
+            },
+          );
+
+          final newSchema = Schema.fromMigrations([insertTable, createIndex].toSet());
+          expect(newSchema.tables, schema.tables);
+          expect(newSchema.version, schema.version);
+        });
+      });
+
+      group('DropIndex', () {
+        test('runs', () {
+          final schema = Schema(
+            8,
+            tables: <SchemaTable>{
+              SchemaTable(
+                'demo',
+                columns: <SchemaColumn>{
+                  SchemaColumn('_brick_id', int,
+                      autoincrement: true, nullable: false, isPrimaryKey: true),
+                },
+                indices: <SchemaIndex>{},
+              )
+            },
+          );
+
+          final newSchema = Schema.fromMigrations([insertTable, createIndex, dropIndex].toSet());
+          expect(newSchema.tables, schema.tables);
+          expect(newSchema.version, schema.version);
+        });
+      });
+
       test('multiple tables', () {
         final schema = Schema(
           2,
@@ -227,14 +275,18 @@ Schema(
       columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
       },
-      indices: <SchemaIndex>{}
+      indices: <SchemaIndex>{
+        
+      }
     ),
     SchemaTable(
       'demo2',
       columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
       },
-      indices: <SchemaIndex>{}
+      indices: <SchemaIndex>{
+        
+      }
     )
   }
 )''');

--- a/packages/brick_sqlite_abstract/test/db/schema_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_test.dart
@@ -226,13 +226,15 @@ Schema(
       'demo',
       columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
-      }
+      },
+      indices: <SchemaIndex>{}
     ),
     SchemaTable(
       'demo2',
       columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
-      }
+      },
+      indices: <SchemaIndex>{}
     )
   }
 )''');

--- a/packages/brick_sqlite_abstract/test/db/schema_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_test.dart
@@ -191,7 +191,6 @@ void main() {
           );
 
           final newSchema = Schema.fromMigrations([insertTable, createIndex].toSet());
-          print(newSchema.forGenerator);
           expect(newSchema.tables, schema.tables);
           expect(newSchema.version, schema.version);
         });

--- a/packages/brick_sqlite_abstract/test/db/schema_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_test.dart
@@ -191,6 +191,7 @@ void main() {
           );
 
           final newSchema = Schema.fromMigrations([insertTable, createIndex].toSet());
+          print(newSchema.forGenerator);
           expect(newSchema.tables, schema.tables);
           expect(newSchema.version, schema.version);
         });
@@ -276,7 +277,7 @@ Schema(
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
       },
       indices: <SchemaIndex>{
-        
+          
       }
     ),
     SchemaTable(
@@ -285,7 +286,7 @@ Schema(
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
       },
       indices: <SchemaIndex>{
-        
+          
       }
     )
   }

--- a/packages/brick_sqlite_abstract/test/db/schema_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/schema_test.dart
@@ -14,7 +14,7 @@ void main() {
         test('calls', () {
           final schema = Schema(
             1,
-            tables: Set.from([
+            tables: <SchemaTable>{
               SchemaTable(
                 'demo',
                 columns: Set<SchemaColumn>.from([
@@ -22,7 +22,7 @@ void main() {
                       autoincrement: true, nullable: false, isPrimaryKey: true)
                 ]),
               )
-            ]),
+            },
           );
 
           final newSchema = Schema.fromMigrations([insertTable].toSet());
@@ -42,7 +42,7 @@ void main() {
         test('runs', () {
           final schema = Schema(
             2,
-            tables: Set.from([
+            tables: <SchemaTable>{
               SchemaTable(
                 'demo1',
                 columns: Set<SchemaColumn>.from([
@@ -50,7 +50,7 @@ void main() {
                       autoincrement: true, nullable: false, isPrimaryKey: true)
                 ]),
               )
-            ]),
+            },
           );
 
           final newSchema = Schema.fromMigrations([insertTable, renameTable].toSet());
@@ -88,7 +88,7 @@ void main() {
         test('runs', () {
           final schema = Schema(
             4,
-            tables: Set.from([
+            tables: <SchemaTable>{
               SchemaTable(
                 'demo',
                 columns: Set<SchemaColumn>.from([
@@ -97,7 +97,7 @@ void main() {
                   SchemaColumn('name', String)
                 ]),
               )
-            ]),
+            },
           );
 
           final newSchema = Schema.fromMigrations([insertTable, insertColumn].toSet());
@@ -122,7 +122,7 @@ void main() {
         test('runs', () {
           final schema = Schema(
             5,
-            tables: Set.from([
+            tables: <SchemaTable>{
               SchemaTable(
                 'demo',
                 columns: Set<SchemaColumn>.from([
@@ -131,7 +131,7 @@ void main() {
                   SchemaColumn('first_name', String)
                 ]),
               )
-            ]),
+            },
           );
 
           final newSchema =
@@ -152,7 +152,7 @@ void main() {
         test('runs', () {
           final schema = Schema(
             6,
-            tables: Set.from([
+            tables: <SchemaTable>{
               SchemaTable(
                 'demo',
                 columns: Set<SchemaColumn>.from([
@@ -161,7 +161,7 @@ void main() {
                   SchemaColumn('demo2_id', int, isForeignKey: true, foreignTableName: 'demo2')
                 ]),
               )
-            ]),
+            },
           );
 
           final newSchema = Schema.fromMigrations([insertTable, insertForeignKey].toSet());
@@ -173,7 +173,7 @@ void main() {
       test('multiple tables', () {
         final schema = Schema(
           2,
-          tables: Set.from([
+          tables: <SchemaTable>{
             SchemaTable(
               'demo',
               columns: Set<SchemaColumn>.from([
@@ -188,7 +188,7 @@ void main() {
                     autoincrement: true, nullable: false, isPrimaryKey: true)
               ]),
             ),
-          ]),
+          },
         );
 
         final newSchema = Schema.fromMigrations([insertTable, Migration2()].toSet());
@@ -221,20 +221,20 @@ void main() {
 Schema(
   2,
   generatorVersion: 1,
-  tables: Set<SchemaTable>.from([
+  tables: <SchemaTable>{
     SchemaTable(
       'demo',
-      columns: Set.from([
+      columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
-      ])
+      }
     ),
     SchemaTable(
       'demo2',
-      columns: Set.from([
+      columns: <SchemaColumn>{
         SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true)
-      ])
+      }
     )
-  ])
+  }
 )''');
     });
   });

--- a/packages/brick_sqlite_generators/lib/src/builders/new_migration_builder.dart
+++ b/packages/brick_sqlite_generators/lib/src/builders/new_migration_builder.dart
@@ -29,17 +29,25 @@ class NewMigrationBuilder<_ClassAnnotation> extends SqliteBaseBuilder<_ClassAnno
     final stopwatch = Stopwatch();
     stopwatch.start();
 
+    // TODO Set.from([ format is deprecated. Remove both of these on the next major release
+    await replaceWithinFile(
+      'db/schema.g.dart',
+      'final Set<Migration> migrations = Set.from([',
+      'final Set<Migration> migrations = <Migration>{',
+    );
+    await replaceWithinFile('db/schema.g.dart', '])', '}');
+
     // in a perfect world, the schema would not be edited in such a brittle way
     // however, reruning the schema generator here doesn't pick up the new migration
     // because it uses the LibraryReader from before the migration is created.
     // this should be revisited in a few build versions to make this flow less brittle
     // and more predictable by using the same schema generator to do all the heavy lifting
+    final newSetPiece = 'final Set<Migration> migrations = <Migration>{\n  Migration$version(),';
     final newPart = "show Migratable;\npart '$version.migration.dart';";
-    final newSetPiece = 'final Set<Migration> migrations = Set.from([\n  Migration$version(),';
 
     await replaceWithinFile(
       'db/schema.g.dart',
-      'final Set<Migration> migrations = Set.from([',
+      'final Set<Migration> migrations = <Migration>{',
       newSetPiece,
     );
     await replaceWithinFile(

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
@@ -49,8 +49,14 @@ class MigrationGenerator extends Generator {
     return rawCommands.map((object) {
       final reader = ConstantReader(object);
       if (_createIndexChecker.isExactlyType(object.type)) {
+        if (!reader.read('columns').isList) {
+          throw ArgumentError(
+              'CreateIndex on ${reader.read('onTable').stringValue} has malformed columns');
+        }
+        final columns = reader.read('columns').listValue.map((o) => o.toStringValue());
+
         return CreateIndex(
-          columns: reader.read('columns').listValue.map((o) => o.toStringValue()),
+          columns: columns?.toList()?.cast<String>() ?? <String>[],
           onTable: reader.read('onTable').stringValue,
           unique: reader.read('unique').boolValue,
         );

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:brick_sqlite_abstract/db.dart';
 
 const _migrationAnnotationChecker = TypeChecker.fromRuntime(Migratable);
+const _createIndexChecker = TypeChecker.fromRuntime(CreateIndex);
 const _dropColumnChecker = TypeChecker.fromRuntime(DropColumn);
 const _dropTableChecker = TypeChecker.fromRuntime(DropTable);
 const _insertColumnChecker = TypeChecker.fromRuntime(InsertColumn);
@@ -46,7 +47,13 @@ class MigrationGenerator extends Generator {
   List<MigrationCommand> _migrationCommandsFromReader(List<DartObject> rawCommands) {
     return rawCommands.map((object) {
       final reader = ConstantReader(object);
-      if (_dropColumnChecker.isExactlyType(object.type)) {
+      if (_createIndexChecker.isExactlyType(object.type)) {
+        return CreateIndex(
+          columns: reader.read('columns').listValue.map((o) => o.toStringValue()),
+          onTable: reader.read('onTable').stringValue,
+          unique: reader.read('unique').boolValue,
+        );
+      } else if (_dropColumnChecker.isExactlyType(object.type)) {
         return DropColumn(
           reader.read('name').stringValue,
           onTable: reader.read('onTable').stringValue,

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/migration_generator.dart
@@ -4,6 +4,7 @@ import 'package:brick_sqlite_abstract/db.dart';
 
 const _migrationAnnotationChecker = TypeChecker.fromRuntime(Migratable);
 const _createIndexChecker = TypeChecker.fromRuntime(CreateIndex);
+const _dropIndexChecker = TypeChecker.fromRuntime(DropIndex);
 const _dropColumnChecker = TypeChecker.fromRuntime(DropColumn);
 const _dropTableChecker = TypeChecker.fromRuntime(DropTable);
 const _insertColumnChecker = TypeChecker.fromRuntime(InsertColumn);
@@ -58,6 +59,8 @@ class MigrationGenerator extends Generator {
           reader.read('name').stringValue,
           onTable: reader.read('onTable').stringValue,
         );
+      } else if (_dropIndexChecker.isExactlyType(object.type)) {
+        return DropIndex(reader.read('name').stringValue);
       } else if (_dropTableChecker.isExactlyType(object.type)) {
         return DropTable(
           reader.read('name').stringValue,

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
@@ -38,7 +38,7 @@ class SqliteSchemaGenerator {
       ${parts.join("\n")}
 
       /// All intelligently-generated migrations from all `@Migratable` classes on disk
-      final Set<Migration> migrations = Set.from([ ${migrationClasses.join(",\n")} ]);
+      final Set<Migration> migrations = <Migration>{ ${migrationClasses.join(",\n")} };
 
       /// A consumable database structure including the latest generated migration.
       final schema = ${newSchema.forGenerator};

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
@@ -8,8 +8,7 @@ import 'package:brick_sqlite_generators/src/sqlite_fields.dart';
 import 'package:meta/meta.dart';
 import 'package:source_gen/source_gen.dart' show LibraryReader;
 import 'package:dart_style/dart_style.dart' as dart_style;
-import 'package:brick_sqlite_abstract/db.dart'
-    show MigrationManager, Schema, SchemaTable, SchemaColumn, InsertForeignKey, InsertTable;
+import 'package:brick_sqlite_abstract/db.dart';
 import 'package:source_gen/source_gen.dart';
 
 final _formatter = dart_style.DartFormatter();
@@ -96,36 +95,46 @@ class SqliteSchemaGenerator {
     final foreignTableName = checker.unFuturedArgType.getDisplayString();
 
     return SchemaTable(
-      InsertForeignKey.joinsTableName(foreignTableColumnDefinition.name,
-          localTableName: localTableName),
-      columns: {
-        SchemaColumn(
-          InsertTable.PRIMARY_KEY_COLUMN,
-          int,
-          autoincrement: true,
-          isPrimaryKey: true,
-          nullable: false,
-        ),
-        SchemaColumn(
-          InsertForeignKey.joinsTableLocalColumnName(localTableName),
-          int,
-          isForeignKey: true,
-          foreignTableName: localTableName,
-          nullable: foreignTableColumnDefinition?.nullable,
-          onDeleteCascade: true,
-          onDeleteSetDefault: false,
-        ),
-        SchemaColumn(
-          InsertForeignKey.joinsTableForeignColumnName(foreignTableName),
-          int,
-          isForeignKey: true,
-          foreignTableName: foreignTableName,
-          nullable: foreignTableColumnDefinition?.nullable,
-          onDeleteCascade: true,
-          onDeleteSetDefault: false,
-        ),
-      },
-    );
+        InsertForeignKey.joinsTableName(foreignTableColumnDefinition.name,
+            localTableName: localTableName),
+        columns: {
+          SchemaColumn(
+            InsertTable.PRIMARY_KEY_COLUMN,
+            int,
+            autoincrement: true,
+            isPrimaryKey: true,
+            nullable: false,
+          ),
+          SchemaColumn(
+            InsertForeignKey.joinsTableLocalColumnName(localTableName),
+            int,
+            isForeignKey: true,
+            foreignTableName: localTableName,
+            nullable: foreignTableColumnDefinition?.nullable,
+            onDeleteCascade: true,
+            onDeleteSetDefault: false,
+          ),
+          SchemaColumn(
+            InsertForeignKey.joinsTableForeignColumnName(foreignTableName),
+            int,
+            isForeignKey: true,
+            foreignTableName: foreignTableName,
+            nullable: foreignTableColumnDefinition?.nullable,
+            onDeleteCascade: true,
+            onDeleteSetDefault: false,
+          ),
+        },
+        indices: {
+          SchemaIndex(
+            columns: [
+              InsertForeignKey.joinsTableLocalColumnName(localTableName),
+              InsertForeignKey.joinsTableForeignColumnName(foreignTableName),
+            ],
+            tableName: InsertForeignKey.joinsTableName(foreignTableColumnDefinition.name,
+                localTableName: localTableName),
+            unique: true,
+          )
+        });
   }
 
   SchemaTable _createTable(String tableName, SqliteFields fields) {

--- a/packages/brick_sqlite_generators/lib/src/sqlite_serialize.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_serialize.dart
@@ -190,7 +190,7 @@ class SqliteSerialize<_Model extends SqliteModel> extends SqliteSerdesGenerator<
 
     // Iterable<Future<SqliteModel>>
     final insertStatement =
-        'INSERT OR REPLACE INTO `${InsertForeignKey.joinsTableName(annotation.name, localTableName: fields.element.name)}` (`${InsertForeignKey.joinsTableLocalColumnName(fields.element.name)}`, `${InsertForeignKey.joinsTableForeignColumnName(checker.unFuturedArgType.getDisplayString())}`)';
+        'INSERT OR IGNORE INTO `${InsertForeignKey.joinsTableName(annotation.name, localTableName: fields.element.name)}` (`${InsertForeignKey.joinsTableLocalColumnName(fields.element.name)}`, `${InsertForeignKey.joinsTableForeignColumnName(checker.unFuturedArgType.getDisplayString())}`)';
     var siblingAssociations = fieldValue;
     var upsertMethod =
         '(await s)?.${InsertTable.PRIMARY_KEY_FIELD} ?? await provider?.upsert<${checker.unFuturedArgType}>((await s), repository: repository)';

--- a/packages/brick_sqlite_generators/pubspec.yaml
+++ b/packages/brick_sqlite_generators/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   brick_build: ^0.0.7
-  brick_sqlite_abstract: ^0.0.7+4
+  brick_sqlite_abstract: ^0.0.8
 
 dev_dependencies:
   test: ">=1.11.0 <2.0.0"

--- a/packages/brick_sqlite_generators/pubspec.yaml
+++ b/packages/brick_sqlite_generators/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 
 dependencies:
   brick_build: ^0.0.7
-  brick_sqlite_abstract: ^0.0.8
+  brick_sqlite_abstract:
+    path: ../brick_sqlite_abstract
 
 dev_dependencies:
   test: ">=1.11.0 <2.0.0"

--- a/packages/brick_sqlite_generators/pubspec.yaml
+++ b/packages/brick_sqlite_generators/pubspec.yaml
@@ -11,8 +11,7 @@ environment:
 
 dependencies:
   brick_build: ^0.0.7
-  brick_sqlite_abstract:
-    path: ../brick_sqlite_abstract
+  brick_sqlite_abstract: ^0.0.8+1
 
 dev_dependencies:
   test: ">=1.11.0 <2.0.0"

--- a/packages/brick_sqlite_generators/test/migration_generator/test_from_identical_schema.dart
+++ b/packages/brick_sqlite_generators/test/migration_generator/test_from_identical_schema.dart
@@ -14,13 +14,9 @@ class Migration1 extends Migration {
   const Migration1() : super(version: version, up: up, down: down);
 }
 
-final schema = Schema(2,
-    generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
-      SchemaTable('User',
-          columns: Set.from([
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('name', String),
-          ]))
-    ]));
+final schema = Schema(2, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('User', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('name', String),
+  })
+});

--- a/packages/brick_sqlite_generators/test/migration_generator/test_from_new_schema.dart
+++ b/packages/brick_sqlite_generators/test/migration_generator/test_from_new_schema.dart
@@ -16,17 +16,17 @@ class Migration1 extends Migration {
   const Migration1() : super(version: version, up: up, down: down);
 }
 
-final schema = Schema(2,
-    generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
-      SchemaTable('User',
-          columns: Set.from([
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('address', String),
-            SchemaColumn('email', String),
-          ]))
-    ]));
+final schema = Schema(
+  2,
+  generatorVersion: 1,
+  tables: <SchemaTable>{
+    SchemaTable('User', columns: <SchemaColumn>{
+      SchemaColumn('_brick_id', int, autoincrement: true, nullable: false, isPrimaryKey: true),
+      SchemaColumn('address', String),
+      SchemaColumn('email', String),
+    })
+  },
+);
 
 final output = r'''
 // GENERATED CODE EDIT WITH CAUTION

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
@@ -27,7 +27,8 @@ final schema = Schema(0,
             SchemaColumn('list', String),
             SchemaColumn('longer_camelized_variable', String),
             SchemaColumn('casing', int)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
@@ -13,23 +13,19 @@ import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
-final schema = Schema(0,
-    generatorVersion: 1,
-    tables: <SchemaTable>{
-      SchemaTable('AllFieldTypes',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('integer', int),
-            SchemaColumn('boolean', bool),
-            SchemaColumn('dub', double),
-            SchemaColumn('string', String),
-            SchemaColumn('list', String),
-            SchemaColumn('longer_camelized_variable', String),
-            SchemaColumn('casing', int)
-          },
-          indices: <SchemaIndex>{})
-    });
+final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('AllFieldTypes', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('integer', int),
+    SchemaColumn('boolean', bool),
+    SchemaColumn('dub', double),
+    SchemaColumn('string', String),
+    SchemaColumn('list', String),
+    SchemaColumn('longer_camelized_variable', String),
+    SchemaColumn('casing', int)
+  }, indices: <SchemaIndex>{})
+});
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
@@ -10,14 +10,14 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('AllFieldTypes',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('integer', int),
@@ -27,8 +27,8 @@ final schema = Schema(0,
             SchemaColumn('list', String),
             SchemaColumn('longer_camelized_variable', String),
             SchemaColumn('casing', int)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
@@ -19,7 +19,8 @@ final schema = Schema(0,
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('name', String, nullable: false)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
@@ -11,17 +11,13 @@ import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
-final schema = Schema(0,
-    generatorVersion: 1,
-    tables: <SchemaTable>{
-      SchemaTable('Nullable',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('name', String, nullable: false)
-          },
-          indices: <SchemaIndex>{})
-    });
+final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('Nullable', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('name', String, nullable: false)
+  }, indices: <SchemaIndex>{})
+});
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
@@ -8,19 +8,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('Nullable',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('name', String, nullable: false)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
@@ -22,38 +22,30 @@ import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
-final schema = Schema(0,
-    generatorVersion: 1,
-    tables: <SchemaTable>{
-      SchemaTable('SqliteAssoc',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true)
-          },
-          indices: <SchemaIndex>{}),
-      SchemaTable('_brick_OneToManyAssocation_assoc',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('l_OneToManyAssocation_brick_id', int,
-                isForeignKey: true,
-                foreignTableName: 'OneToManyAssocation',
-                onDeleteCascade: true,
-                onDeleteSetDefault: false),
-            SchemaColumn('f_SqliteAssoc_brick_id', int,
-                isForeignKey: true,
-                foreignTableName: 'SqliteAssoc',
-                onDeleteCascade: true,
-                onDeleteSetDefault: false)
-          },
-          indices: <SchemaIndex>{SchemaIndex(columns: ['l_OneToManyAssocation_brick_id', 'f_SqliteAssoc_brick_id'], unique: true)}),
-      SchemaTable('OneToManyAssocation',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true)
-          },
-          indices: <SchemaIndex>{})
-    });
+final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('SqliteAssoc', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true)
+  }, indices: <SchemaIndex>{}),
+  SchemaTable('_brick_OneToManyAssocation_assoc', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('l_OneToManyAssocation_brick_id', int,
+        isForeignKey: true,
+        foreignTableName: 'OneToManyAssocation',
+        onDeleteCascade: true,
+        onDeleteSetDefault: false),
+    SchemaColumn('f_SqliteAssoc_brick_id', int,
+        isForeignKey: true,
+        foreignTableName: 'SqliteAssoc',
+        onDeleteCascade: true,
+        onDeleteSetDefault: false)
+  }, indices: <SchemaIndex>{SchemaIndex(columns: ['l_OneToManyAssocation_brick_id', 'f_SqliteAssoc_brick_id'], unique: true)}),
+  SchemaTable('OneToManyAssocation', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true)
+  }, indices: <SchemaIndex>{})
+});
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
@@ -19,19 +19,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('SqliteAssoc',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          ])),
+          }),
       SchemaTable('_brick_OneToManyAssocation_assoc',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('l_OneToManyAssocation_brick_id', int,
@@ -44,13 +44,13 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: true,
                 onDeleteSetDefault: false)
-          ])),
+          }),
       SchemaTable('OneToManyAssocation',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
@@ -29,7 +29,8 @@ final schema = Schema(0,
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          }),
+          },
+          indices: <SchemaIndex>{}),
       SchemaTable('_brick_OneToManyAssocation_assoc',
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
@@ -44,12 +45,14 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: true,
                 onDeleteSetDefault: false)
-          }),
+          },
+          indices: <SchemaIndex>{SchemaIndex(columns: ['l_OneToManyAssocation_brick_id', 'f_SqliteAssoc_brick_id'], unique: true)}),
       SchemaTable('OneToManyAssocation',
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
@@ -40,7 +40,11 @@ final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
         foreignTableName: 'SqliteAssoc',
         onDeleteCascade: true,
         onDeleteSetDefault: false)
-  }, indices: <SchemaIndex>{SchemaIndex(columns: ['l_OneToManyAssocation_brick_id', 'f_SqliteAssoc_brick_id'], unique: true)}),
+  }, indices: <SchemaIndex>{
+    SchemaIndex(
+        columns: ['l_OneToManyAssocation_brick_id', 'f_SqliteAssoc_brick_id'],
+        unique: true)
+  }),
   SchemaTable('OneToManyAssocation', columns: <SchemaColumn>{
     SchemaColumn('_brick_id', int,
         autoincrement: true, nullable: false, isPrimaryKey: true)

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
@@ -29,7 +29,8 @@ final schema = Schema(0,
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          }),
+          },
+          indices: <SchemaIndex>{}),
       SchemaTable('OneToOneAssocation',
           columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
@@ -44,7 +45,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
@@ -26,8 +26,7 @@ final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
   SchemaTable('SqliteAssoc', columns: <SchemaColumn>{
     SchemaColumn('_brick_id', int,
         autoincrement: true, nullable: false, isPrimaryKey: true)
-  },
-  indices: <SchemaIndex>{}),
+  }, indices: <SchemaIndex>{}),
   SchemaTable('OneToOneAssocation', columns: <SchemaColumn>{
     SchemaColumn('_brick_id', int,
         autoincrement: true, nullable: false, isPrimaryKey: true),

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
@@ -22,32 +22,27 @@ import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
-final schema = Schema(0,
-    generatorVersion: 1,
-    tables: <SchemaTable>{
-      SchemaTable('SqliteAssoc',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true)
-          },
-          indices: <SchemaIndex>{}),
-      SchemaTable('OneToOneAssocation',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('assoc_SqliteAssoc_brick_id', int,
-                isForeignKey: true,
-                foreignTableName: 'SqliteAssoc',
-                onDeleteCascade: false,
-                onDeleteSetDefault: false),
-            SchemaColumn('assoc2_SqliteAssoc_brick_id', int,
-                isForeignKey: true,
-                foreignTableName: 'SqliteAssoc',
-                onDeleteCascade: false,
-                onDeleteSetDefault: false)
-          },
-          indices: <SchemaIndex>{})
-    });
+final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('SqliteAssoc', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true)
+  },
+  indices: <SchemaIndex>{}),
+  SchemaTable('OneToOneAssocation', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('assoc_SqliteAssoc_brick_id', int,
+        isForeignKey: true,
+        foreignTableName: 'SqliteAssoc',
+        onDeleteCascade: false,
+        onDeleteSetDefault: false),
+    SchemaColumn('assoc2_SqliteAssoc_brick_id', int,
+        isForeignKey: true,
+        foreignTableName: 'SqliteAssoc',
+        onDeleteCascade: false,
+        onDeleteSetDefault: false)
+  }, indices: <SchemaIndex>{})
+});
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
@@ -19,19 +19,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('SqliteAssoc',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true)
-          ])),
+          }),
       SchemaTable('OneToOneAssocation',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('assoc_SqliteAssoc_brick_id', int,
@@ -44,8 +44,8 @@ final schema = Schema(0,
                 foreignTableName: 'SqliteAssoc',
                 onDeleteCascade: false,
                 onDeleteSetDefault: false)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
@@ -50,19 +50,19 @@ import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
-final Set<Migration> migrations = Set.from([]);
+final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
 final schema = Schema(0,
     generatorVersion: 1,
-    tables: Set<SchemaTable>.from([
+    tables: <SchemaTable>{
       SchemaTable('Simple',
-          columns: Set.from([
+          columns: <SchemaColumn>{
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('name', String)
-          ]))
-    ]));
+          })
+    });
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
@@ -53,17 +53,13 @@ import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 final Set<Migration> migrations = <Migration>{};
 
 /// A consumable database structure including the latest generated migration.
-final schema = Schema(0,
-    generatorVersion: 1,
-    tables: <SchemaTable>{
-      SchemaTable('Simple',
-          columns: <SchemaColumn>{
-            SchemaColumn('_brick_id', int,
-                autoincrement: true, nullable: false, isPrimaryKey: true),
-            SchemaColumn('name', String)
-          },
-          indices: <SchemaIndex>{})
-    });
+final schema = Schema(0, generatorVersion: 1, tables: <SchemaTable>{
+  SchemaTable('Simple', columns: <SchemaColumn>{
+    SchemaColumn('_brick_id', int,
+        autoincrement: true, nullable: false, isPrimaryKey: true),
+    SchemaColumn('name', String)
+  }, indices: <SchemaIndex>{})
+});
 ''';
 
 /// [SqliteSerializable] **does not** produce code.

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
@@ -61,7 +61,8 @@ final schema = Schema(0,
             SchemaColumn('_brick_id', int,
                 autoincrement: true, nullable: false, isPrimaryKey: true),
             SchemaColumn('name', String)
-          })
+          },
+          indices: <SchemaIndex>{})
     });
 ''';
 


### PR DESCRIPTION
* Use `CreateIndex` in the generator
* Add `DropIndex` command
* Use collection literals in generated files to comply with standard analysis_options
* Track created indices in the schema
* Generate `CreateIndex` programmatically