### PR TITLE
prevent duplicate processing when response time is > 5s

### DIFF
--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Gracefully handle `SocketException` errors when the application is offline
+* Do not reprocess queue requests during a single attempt. Server response times may be greater than the reattempt timer; in these situations, requests should remain locked.
 
 ## 0.1.0
 

--- a/packages/brick_offline_first/lib/offline_first_with_rest.dart
+++ b/packages/brick_offline_first/lib/offline_first_with_rest.dart
@@ -176,6 +176,7 @@ abstract class OfflineFirstWithRestRepository
   Future<List<_Model>> hydrate<_Model extends OfflineFirstWithRestModel>({
     bool deserializeSqlite = true,
     Query query,
+    bool requireRemote = false,
   }) async {
     try {
       return await super.hydrate(deserializeSqlite: deserializeSqlite, query: query);

--- a/packages/brick_offline_first/lib/offline_first_with_rest.dart
+++ b/packages/brick_offline_first/lib/offline_first_with_rest.dart
@@ -176,7 +176,6 @@ abstract class OfflineFirstWithRestRepository
   Future<List<_Model>> hydrate<_Model extends OfflineFirstWithRestModel>({
     bool deserializeSqlite = true,
     Query query,
-    bool requireRemote = false,
   }) async {
     try {
       return await super.hydrate(deserializeSqlite: deserializeSqlite, query: query);

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
@@ -38,7 +38,7 @@ class OfflineQueueHttpClient extends http.BaseClient {
     if (cacheItem.requestIsPush) {
       final db = await requestManager.getDb();
       // Log immediately before we make the request
-      await cacheItem.insert(db, logger: _logger);
+      await cacheItem.insertOrUpdate(db, logger: _logger);
     }
 
     /// When the request is null or an error has occurred, an error-like
@@ -52,17 +52,13 @@ class OfflineQueueHttpClient extends http.BaseClient {
       // Attempt to make HTTP Request
       final resp = await _inner.send(request);
 
-      if (cacheItem.requestIsPush) {
+      if (cacheItem.requestIsPush &&
+          resp != null &&
+          !reattemptForStatusCodes.contains(resp.statusCode)) {
+        // request was successfully sent and can be removed
+        _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
         final db = await requestManager.getDb();
-        if (resp != null && !reattemptForStatusCodes.contains(resp.statusCode)) {
-          // request was successfully sent and can be removed
-          _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
-          await cacheItem.delete(db);
-        } else {
-          // Unlock the row and increment attempts
-          final db = await requestManager.getDb();
-          await cacheItem.update(db, logger: _logger);
-        }
+        await cacheItem.delete(db);
       }
 
       return resp ?? _genericErrorResponse;

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
@@ -51,9 +51,9 @@ class OfflineQueueHttpClient extends http.BaseClient {
     try {
       // Attempt to make HTTP Request
       final resp = await _inner.send(request);
-      final db = await requestManager.getDb();
 
       if (cacheItem.requestIsPush) {
+        final db = await requestManager.getDb();
         if (resp != null && !reattemptForStatusCodes.contains(resp.statusCode)) {
           // request was successfully sent and can be removed
           _logger.finest('removing from queue: ${cacheItem.toSqlite()}');

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -50,9 +50,8 @@ class RequestSqliteCache {
     return 0;
   }
 
-  /// If the request already exists in the database, increment attemps and
-  /// set `updated_at` to current time.
-  Future<int> insertOrUpdate(Database db, {Logger logger}) async {
+  /// Add new requests to the database
+  Future<int> insert(Database db, {Logger logger}) async {
     final response = await _findRequestInDatabase(db);
 
     return db.transaction((txn) async {
@@ -65,6 +64,17 @@ class RequestSqliteCache {
           serialized,
         );
       }
+
+      return null;
+    });
+  }
+
+  /// If the request already exists in the database, increment attemps and
+  /// set `updated_at` to current time.
+  Future<int> update(Database db, {Logger logger}) async {
+    final response = await _findRequestInDatabase(db);
+
+    return db.transaction((txn) async {
       final methodWithUrl =
           [response[HTTP_JOBS_REQUEST_METHOD_COLUMN], response[HTTP_JOBS_URL_COLUMN]].join(' ');
       logger?.warning(

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -50,8 +50,9 @@ class RequestSqliteCache {
     return 0;
   }
 
-  /// Add new requests to the database
-  Future<int> insert(Database db, {Logger logger}) async {
+  /// If the request already exists in the database, increment attemps and
+  /// set `updated_at` to current time.
+  Future<int> insertOrUpdate(Database db, {Logger logger}) async {
     final response = await _findRequestInDatabase(db);
 
     return db.transaction((txn) async {
@@ -64,17 +65,6 @@ class RequestSqliteCache {
           serialized,
         );
       }
-
-      return null;
-    });
-  }
-
-  /// If the request already exists in the database, increment attemps and
-  /// set `updated_at` to current time.
-  Future<int> update(Database db, {Logger logger}) async {
-    final response = await _findRequestInDatabase(db);
-
-    return db.transaction((txn) async {
       final methodWithUrl =
           [response[HTTP_JOBS_REQUEST_METHOD_COLUMN], response[HTTP_JOBS_URL_COLUMN]].join(' ');
       logger?.warning(

--- a/packages/brick_offline_first/pubspec.yaml
+++ b/packages/brick_offline_first/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   brick_core: ^0.0.6
   brick_offline_first_abstract: ^0.0.7
   brick_rest: ^0.0.7+1
-  brick_sqlite: ^0.1.1
+  brick_sqlite: ^0.1.2
   brick_sqlite_abstract: 0.0.9+1
   dart_style: ^1.2.4
   http: ^0.12.0

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(request.method, 'POST');
 
       final asCacheItem = RequestSqliteCache(request);
-      await asCacheItem.insertOrUpdate(await _requestManager.getDb());
+      await asCacheItem.update(await _requestManager.getDb());
       final req = await _requestManager.prepareNextRequestToProcess();
       expect(req.method, 'PUT');
     });
@@ -63,7 +63,7 @@ void main() {
       expect(request.method, 'POST');
 
       final asCacheItem = RequestSqliteCache(request);
-      await asCacheItem.insertOrUpdate(await requestManager.getDb());
+      await asCacheItem.insert(await requestManager.getDb());
       final req = await requestManager.prepareNextRequestToProcess();
       expect(req.method, 'POST');
     });

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -64,8 +64,9 @@ void main() {
 
       final asCacheItem = RequestSqliteCache(request);
       await asCacheItem.insertOrUpdate(await requestManager.getDb());
+      // Do not retry request if the row is locked and serial processing is active
       final req = await requestManager.prepareNextRequestToProcess();
-      expect(req.method, 'POST');
+      expect(req, isNull);
     });
 
     test('#deleteUnprocessedRequest', () async {

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -47,7 +47,7 @@ void main() {
       expect(request.method, 'POST');
 
       final asCacheItem = RequestSqliteCache(request);
-      await asCacheItem.update(await _requestManager.getDb());
+      await asCacheItem.insertOrUpdate(await _requestManager.getDb());
       final req = await _requestManager.prepareNextRequestToProcess();
       expect(req.method, 'PUT');
     });
@@ -63,7 +63,7 @@ void main() {
       expect(request.method, 'POST');
 
       final asCacheItem = RequestSqliteCache(request);
-      await asCacheItem.insert(await requestManager.getDb());
+      await asCacheItem.insertOrUpdate(await requestManager.getDb());
       final req = await requestManager.prepareNextRequestToProcess();
       expect(req.method, 'POST');
     });

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -65,32 +65,34 @@ void main() {
     test('#delete', () async {
       final db = await requestManager.getDb();
       expect(await requestManager.unprocessedRequests(), isEmpty);
-      await getResp.insert(db);
+      await getResp.insertOrUpdate(db);
       expect(await requestManager.unprocessedRequests(), isNotEmpty);
       await getResp.delete(db);
       expect(await requestManager.unprocessedRequests(), isEmpty);
     });
 
-    test('#insert', () async {
+    group('#insertOrUpdate', () {
       final logger = MockLogger();
-      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
-      final uninserted = RequestSqliteCache(uninsertedRequest);
-      final db = await requestManager.getDb();
-      expect(await requestManager.unprocessedRequests(), isEmpty);
-      await uninserted.insert(db, logger: logger);
-      expect(await requestManager.unprocessedRequests(), isNotEmpty);
-      verify(logger.fine(any));
-    });
 
-    test('#update', () async {
-      final logger = MockLogger();
-      final db = await requestManager.getDb();
-      await getResp.insert(db);
-      await getResp.update(db, logger: logger);
-      final request = await requestManager.unprocessedRequests();
-      verify(logger.warning(any));
+      test('insert', () async {
+        final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+        final uninserted = RequestSqliteCache(uninsertedRequest);
+        final db = await requestManager.getDb();
+        expect(await requestManager.unprocessedRequests(), isEmpty);
+        await uninserted.insertOrUpdate(db, logger: logger);
+        expect(await requestManager.unprocessedRequests(), isNotEmpty);
+        verify(logger.fine(any));
+      });
 
-      expect(request.first[HTTP_JOBS_ATTEMPTS_COLUMN], 2);
+      test('update', () async {
+        final db = await requestManager.getDb();
+        await getResp.insertOrUpdate(db);
+        await getResp.insertOrUpdate(db, logger: logger);
+        final request = await requestManager.unprocessedRequests();
+        verify(logger.warning(any));
+
+        expect(request.first[HTTP_JOBS_ATTEMPTS_COLUMN], 2);
+      });
     });
 
     group('.toRequest', () {

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -65,34 +65,32 @@ void main() {
     test('#delete', () async {
       final db = await requestManager.getDb();
       expect(await requestManager.unprocessedRequests(), isEmpty);
-      await getResp.insertOrUpdate(db);
+      await getResp.insert(db);
       expect(await requestManager.unprocessedRequests(), isNotEmpty);
       await getResp.delete(db);
       expect(await requestManager.unprocessedRequests(), isEmpty);
     });
 
-    group('#insertOrUpdate', () {
+    test('#insert', () async {
       final logger = MockLogger();
+      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+      final uninserted = RequestSqliteCache(uninsertedRequest);
+      final db = await requestManager.getDb();
+      expect(await requestManager.unprocessedRequests(), isEmpty);
+      await uninserted.insert(db, logger: logger);
+      expect(await requestManager.unprocessedRequests(), isNotEmpty);
+      verify(logger.fine(any));
+    });
 
-      test('insert', () async {
-        final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
-        final uninserted = RequestSqliteCache(uninsertedRequest);
-        final db = await requestManager.getDb();
-        expect(await requestManager.unprocessedRequests(), isEmpty);
-        await uninserted.insertOrUpdate(db, logger: logger);
-        expect(await requestManager.unprocessedRequests(), isNotEmpty);
-        verify(logger.fine(any));
-      });
+    test('#update', () async {
+      final logger = MockLogger();
+      final db = await requestManager.getDb();
+      await getResp.insert(db);
+      await getResp.update(db, logger: logger);
+      final request = await requestManager.unprocessedRequests();
+      verify(logger.warning(any));
 
-      test('update', () async {
-        final db = await requestManager.getDb();
-        await getResp.insertOrUpdate(db);
-        await getResp.insertOrUpdate(db, logger: logger);
-        final request = await requestManager.unprocessedRequests();
-        verify(logger.warning(any));
-
-        expect(request.first[HTTP_JOBS_ATTEMPTS_COLUMN], 2);
-      });
+      expect(request.first[HTTP_JOBS_ATTEMPTS_COLUMN], 2);
     });
 
     group('.toRequest', () {

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -95,6 +95,18 @@ void main() {
       });
     });
 
+    test('#unlock', () async {
+      final logger = MockLogger();
+      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+      final uninserted = RequestSqliteCache(uninsertedRequest);
+      final db = await requestManager.getDb();
+      expect(await requestManager.unprocessedRequests(), isEmpty);
+      await uninserted.insertOrUpdate(db, logger: logger);
+      await uninserted.unlock(db);
+      final request = await requestManager.unprocessedRequests();
+      expect(request.first[HTTP_JOBS_LOCKED_COLUMN], 0);
+    });
+
     group('.toRequest', () {
       test('basic', () {
         final request = RequestSqliteCache.sqliteToRequest({

--- a/packages/brick_sqlite/CHANGELOG.md
+++ b/packages/brick_sqlite/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.1.2
+
 * When searching with `doesNotContain` apply same fuzzy search `%` that `Compare.contains` enjoys
 
 ## 0.1.1

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -37,13 +37,14 @@ class SqliteProvider implements Provider<SqliteModel> {
   final String dbName;
 
   /// The glue between app models and generated adapters
+  @override
   final SqliteModelDictionary modelDictionary;
 
   /// Ensure commands are run synchronously. This significantly benefits stability while
   /// preventing database lockups (has a very, very minor performance expense).
   final Lock _lock;
 
-  Logger _logger;
+  final Logger _logger;
 
   SqliteProvider(
     this.dbName, {
@@ -64,6 +65,7 @@ class SqliteProvider implements Provider<SqliteModel> {
   }
 
   /// Remove record from SQLite. [query] is ignored.
+  @override
   Future<int> delete<_Model extends SqliteModel>(instance, {query, repository}) async {
     final adapter = modelDictionary.adapterFor[_Model];
     final db = await _db;
@@ -121,6 +123,7 @@ class SqliteProvider implements Provider<SqliteModel> {
   /// to produce `SELECT * FROM "TableName" ORDER BY created_at ASC, name ASC;`, `providerArgs` would
   /// equal `'providerArgs': { 'orderBy': 'created_at ASC, name ASC' }` with column names defined.
   /// As Brick manages column names, this is not recommended and should be written only when necessary.
+  @override
   Future<List<_Model>> get<_Model extends SqliteModel>({
     query,
     repository,
@@ -211,7 +214,7 @@ class SqliteProvider implements Provider<SqliteModel> {
 
     if (results.isEmpty || results.first.isEmpty) {
       // otherwise an empty sql result will generate a blank model
-      return List<_Model>();
+      return <_Model>[];
     }
 
     return await Future.wait<_Model>(
@@ -255,6 +258,7 @@ class SqliteProvider implements Provider<SqliteModel> {
   }
 
   /// Insert record into SQLite. Returns the primary key of the record inserted
+  @override
   Future<int> upsert<_Model extends SqliteModel>(instance, {query, repository}) async {
     if (instance == null) return NEW_RECORD_ID;
 

--- a/packages/brick_sqlite/pubspec.yaml
+++ b/packages/brick_sqlite/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_sqlite
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: '>=2.5.0 <3.0.0'


### PR DESCRIPTION
Do not reprocess queue requests during a single attempt. Server response times may be greater than the reattempt timer; in these situations, requests should remain locked.