### PR TITLE
properly access SQLite to prevent lockups

### DIFF
--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased
 
+## 0.1.1
+
 * Gracefully handle `SocketException` errors when the application is offline
 * Call `exists` in `OfflineFirstRepository#get` after the memory provider has already been queried. This method can query the SqliteProvider which is an unnecessary database call when the model exists in the memory provider.
+* RequestSqliteCacheManager: access SQLite db safely to [avoid race conditions](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue)
 
 ## 0.1.0
 

--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Gracefully handle `SocketException` errors when the application is offline
 * Call `exists` in `OfflineFirstRepository#get` after the memory provider has already been queried. This method can query the SqliteProvider which is an unnecessary database call when the model exists in the memory provider.
 * RequestSqliteCacheManager: access SQLite db safely to [avoid race conditions](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue)
+* RequestSqliteCacheManager: refactor database path. This does not change the database's existing path as the use of `getDatabasesPath()` in the implementation was duplicating [default functionality](https://github.com/tekartik/sqflite/tree/master/sqflite#opening-a-database)
 
 ## 0.1.0
 

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -1,7 +1,6 @@
 import 'package:http/http.dart' as http;
 import 'package:sqflite/sqflite.dart';
 import 'package:brick_offline_first/src/offline_queue/request_sqlite_cache.dart';
-import 'package:path/path.dart' as p;
 import 'package:meta/meta.dart';
 
 /// Fetch and delete [RequestSqliteCache]s.
@@ -166,10 +165,7 @@ class RequestSqliteCacheManager {
       if (databaseFactory != null) {
         _db = databaseFactory.openDatabase(databaseName);
       } else {
-        _db = getDatabasesPath().then((databasesPath) {
-          final path = p.join(databasesPath, databaseName);
-          return openDatabase(path);
-        });
+        _db = openDatabase(databaseName);
       }
     }
 

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -19,7 +19,7 @@ class RequestSqliteCacheManager {
   /// `sqlite_common` constant `inMemoryDatabasePath`.
   final String databaseName;
 
-  Database _db;
+  Future<Database> _db;
 
   String get orderByStatement {
     if (!serialProcessing) {
@@ -161,17 +161,19 @@ class RequestSqliteCacheManager {
     ].join(' ');
   }
 
-  Future<Database> getDb() async {
-    if (_db?.isOpen == true) return _db;
-
-    if (databaseFactory != null) {
-      return _db = await databaseFactory.openDatabase(databaseName);
+  Future<Database> getDb() {
+    if (_db == null) {
+      if (databaseFactory != null) {
+        _db = databaseFactory.openDatabase(databaseName);
+      } else {
+        _db = getDatabasesPath().then((databasesPath) {
+          final path = p.join(databasesPath, databaseName);
+          return openDatabase(path);
+        });
+      }
     }
 
-    final databasesPath = await getDatabasesPath();
-    final path = p.join(databasesPath, databaseName);
-
-    return _db = await openDatabase(path);
+    return _db;
   }
 }
 

--- a/packages/brick_offline_first/pubspec.yaml
+++ b/packages/brick_offline_first/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_offline_
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
@@ -15,7 +15,7 @@ dependencies:
   brick_core: ^0.0.6
   brick_offline_first_abstract: ^0.0.7
   brick_rest: ^0.0.7+1
-  brick_sqlite: ^0.1.4
+  brick_sqlite: ^0.1.5
   brick_sqlite_abstract: 0.0.9+1
   dart_style: ^1.2.4
   http: ^0.12.0

--- a/packages/brick_sqlite/CHANGELOG.md
+++ b/packages/brick_sqlite/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+## 0.1.5
+
+* Access SQLite db safely to [avoid race conditions](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue)
+* Lint: do not use implicit types
+
 ## 0.1.4
 
 * Handle empty conditions when constructing a statement from a `WherePhrase`

--- a/packages/brick_sqlite/lib/memory_cache_provider.dart
+++ b/packages/brick_sqlite/lib/memory_cache_provider.dart
@@ -64,7 +64,7 @@ class MemoryCacheProvider extends Provider<SqliteModel> {
     // If this query is searching for a unique identifier, return that specific record
     final byId = Where.firstByField(InsertTable.PRIMARY_KEY_FIELD, query?.where);
     if (byId?.value != null) {
-      final object = managedObjects[_Model][byId.value];
+      final object = managedObjects[_Model][byId.value] as _Model;
       if (object != null) return [object];
     }
 
@@ -101,6 +101,6 @@ class MemoryCacheProvider extends Provider<SqliteModel> {
     if (!manages(_Model)) return null;
     logger.finest('#upsert: $_Model, $instance, $query');
     hydrate<_Model>([instance]);
-    return managedObjects[_Model][instance.primaryKey];
+    return managedObjects[_Model][instance.primaryKey] as _Model;
   }
 }

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -53,22 +53,29 @@ class SqliteProvider implements Provider<SqliteModel> {
   })  : _lock = Lock(reentrant: true),
         _logger = Logger('SqliteProvider');
 
-  Database _openDb;
-  Future<Database> get _db async {
-    if (_openDb?.isOpen == true) return _openDb;
+  Future<Database> _openDb;
 
+  @protected
+  Future<Database> getDb() {
+    _openDb ??= _initDb();
+    return _openDb;
+  }
+
+  Future<Database> _initDb() async {
     if (databaseFactory != null) {
-      return _openDb = await databaseFactory.openDatabase(dbName);
+      final db = await databaseFactory.openDatabase(dbName);
+      return db;
     }
 
-    return _openDb = await openDatabase(dbName);
+    final db = await openDatabase(dbName);
+    return db;
   }
 
   /// Remove record from SQLite. [query] is ignored.
   @override
   Future<int> delete<_Model extends SqliteModel>(instance, {query, repository}) async {
     final adapter = modelDictionary.adapterFor[_Model];
-    final db = await _db;
+    final db = await getDb();
     final existingPrimaryKey = await adapter.primaryKeyByUniqueColumns(instance, db);
 
     if (instance.isNewRecord || existingPrimaryKey == null) {
@@ -111,7 +118,7 @@ class SqliteProvider implements Provider<SqliteModel> {
       statement = statement.replaceAll('COUNT(*)', InsertTable.PRIMARY_KEY_COLUMN);
     }
 
-    final countQuery = await (await _db).rawQuery(statement, sqlQuery.values);
+    final countQuery = await (await getDb()).rawQuery(statement, sqlQuery.values);
     final count = offsetIsPresent ? countQuery?.length : Sqflite.firstIntValue(countQuery ?? []);
 
     return (count ?? 0) > 0;
@@ -150,7 +157,7 @@ class SqliteProvider implements Provider<SqliteModel> {
   }
 
   Future<int> lastMigrationVersion() async {
-    final db = await _db;
+    final db = await getDb();
 
     // ensure migrations table exists
     await db.execute(
@@ -167,13 +174,13 @@ class SqliteProvider implements Provider<SqliteModel> {
       return -1;
     }
 
-    return sqliteVersions.first['version'];
+    return sqliteVersions.first['version'] as int;
   }
 
   /// Update database structure with latest migrations. Note that this will run
   /// the [migrations] in the order provided.
   Future<void> migrate(List<Migration> migrations) async {
-    final db = await _db;
+    final db = await getDb();
 
     // Ensure foreign keys are enabled
     await db.execute('PRAGMA foreign_keys = ON');
@@ -219,7 +226,7 @@ class SqliteProvider implements Provider<SqliteModel> {
     final adapter = modelDictionary.adapterFor[_Model];
 
     final results = await _lock.synchronized(() async {
-      return (await _db).rawQuery(sql, arguments);
+      return (await getDb()).rawQuery(sql, arguments);
     });
 
     if (results.isEmpty || results.first.isEmpty) {
@@ -228,23 +235,25 @@ class SqliteProvider implements Provider<SqliteModel> {
     }
 
     return await Future.wait<_Model>(
-      results.map((row) => adapter.fromSqlite(row, provider: this, repository: repository)),
+      results.map(
+        (row) => adapter.fromSqlite(row, provider: this, repository: repository) as Future<_Model>,
+      ),
     );
   }
 
   /// Execute a raw SQL statement. **Advanced use only**.
   Future<void> rawExecute(String sql, [List arguments]) async {
-    return await (await _db).execute(sql, arguments);
+    return await (await getDb()).execute(sql, arguments);
   }
 
   /// Insert with a raw SQL statement. **Advanced use only**.
   Future<int> rawInsert(String sql, [List arguments]) async {
-    return await (await _db).rawInsert(sql, arguments);
+    return await (await getDb()).rawInsert(sql, arguments);
   }
 
   /// Query with a raw SQL statement. **Advanced use only**.
   Future<List<Map>> rawQuery(String sql, [List arguments]) async {
-    return await (await _db).rawQuery(sql, arguments);
+    return await (await getDb()).rawQuery(sql, arguments);
   }
 
   /// Reset the DB by deleting and recreating it.
@@ -252,7 +261,7 @@ class SqliteProvider implements Provider<SqliteModel> {
   /// **WARNING:** This is a destructive, irrevisible action.
   Future<void> resetDb() async {
     try {
-      await (await _db).close();
+      await (await getDb()).close();
 
       if (databaseFactory == null) {
         await deleteDatabase(dbName);
@@ -261,7 +270,7 @@ class SqliteProvider implements Provider<SqliteModel> {
       }
 
       // recreate
-      await _db;
+      await getDb();
     } on FileSystemException {
       // noop
     }
@@ -273,7 +282,7 @@ class SqliteProvider implements Provider<SqliteModel> {
     if (instance == null) return NEW_RECORD_ID;
 
     final adapter = modelDictionary.adapterFor[_Model];
-    final db = await _db;
+    final db = await getDb();
 
     await adapter.beforeSave(instance, provider: this, repository: repository);
     await instance.beforeSave(provider: this, repository: repository);
@@ -318,12 +327,12 @@ class SqliteProvider implements Provider<SqliteModel> {
     String localTableName,
     String foreignTableName,
   ) async {
-    final db = await _db;
+    final db = await getDb();
 
     final rawIds = await db
         .rawQuery('SELECT $columnName, ${InsertTable.PRIMARY_KEY_COLUMN} FROM `$localTableName`');
     for (var result in rawIds) {
-      final ids = jsonDecode(result[columnName] ?? '[]');
+      final ids = jsonDecode(result[columnName] as String ?? '[]');
       for (var id in ids) {
         // ignore deleted associations as they'll throw contraint exceptions
         final hasAssociation = await db.rawQuery(

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -141,7 +141,6 @@ class SqliteProvider implements Provider<SqliteModel> {
   }
 
   /// Access the latest instantiation of the database [safely](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue).
-  ///
   @protected
   Future<Database> getDb() {
     if (_openDb == null) {

--- a/packages/brick_sqlite/lib/src/sqlite/alter_column_helper.dart
+++ b/packages/brick_sqlite/lib/src/sqlite/alter_column_helper.dart
@@ -72,7 +72,7 @@ class AlterColumnHelper {
   /// Given new columns, create the SQLite statement
   String newColumnsExpression(List<Map<String, dynamic>> columns) {
     return columns.map((Map<String, dynamic> column) {
-      final List<String> definition = [column['name'], column['type']];
+      final definition = [column['name'] as String, column['type'] as String];
 
       if (column['notnull'] == 1) {
         definition.add('NOT NULL');

--- a/packages/brick_sqlite/pubspec.yaml
+++ b/packages/brick_sqlite/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_sqlite
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.1.4
+version: 0.1.5
 
 environment:
   sdk: '>=2.5.0 <3.0.0'

--- a/packages/brick_sqlite/test/__mocks__.dart
+++ b/packages/brick_sqlite/test/__mocks__.dart
@@ -20,8 +20,8 @@ class DemoModelAdapter with SqliteAdapter<DemoModel> {
 
   @override
   Future<DemoModel> fromSqlite(map, {provider, repository}) {
-    final composedModel = DemoModel(map['full_name'])
-      ..primaryKey = map[InsertTable.PRIMARY_KEY_COLUMN];
+    final composedModel = DemoModel(map['full_name'] as String)
+      ..primaryKey = map[InsertTable.PRIMARY_KEY_COLUMN] as int;
     return Future.value(composedModel);
   }
 


### PR DESCRIPTION
SQFlite has [a well-documented solution and guidance](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue) about how to access the database. It's "BAD" example is exactly what the existing implementation did; this PR changes SqliteProvider to the "GOOD" example.