### PR TITLE
patch sqlite reset

### DIFF
--- a/packages/brick_offline_first/pubspec.yaml
+++ b/packages/brick_offline_first/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   brick_core: ^0.0.6
   brick_offline_first_abstract: ^0.0.7
   brick_rest: ^0.0.7+1
-  brick_sqlite: ^0.1.5
+  brick_sqlite: ^0.1.5+1
   brick_sqlite_abstract: 0.0.9+1
   dart_style: ^1.2.4
   http: ^0.12.0

--- a/packages/brick_sqlite/CHANGELOG.md
+++ b/packages/brick_sqlite/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.5+1
 
 * Fix: recreate SQLite DB after reset instead of attempting to open a closed DB
+
 ## 0.1.5
 
 * Access SQLite db safely to [avoid race conditions](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue)

--- a/packages/brick_sqlite/CHANGELOG.md
+++ b/packages/brick_sqlite/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 0.1.5+1
+
+* Fix: recreate SQLite DB after reset instead of attempting to open a closed DB
 ## 0.1.5
 
 * Access SQLite db safely to [avoid race conditions](https://github.com/tekartik/sqflite/blob/master/sqflite/doc/opening_db.md#prevent-database-locked-issue)

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -266,9 +266,8 @@ class SqliteProvider implements Provider<SqliteModel> {
         await databaseFactory.deleteDatabase(dbName);
       }
 
-      _openDb = null;
-
       // recreate
+      _openDb = null;
       await getDb();
     } on FileSystemException {
       // noop

--- a/packages/brick_sqlite/lib/sqlite.dart
+++ b/packages/brick_sqlite/lib/sqlite.dart
@@ -266,6 +266,8 @@ class SqliteProvider implements Provider<SqliteModel> {
         await databaseFactory.deleteDatabase(dbName);
       }
 
+      _openDb = null;
+
       // recreate
       await getDb();
     } on FileSystemException {

--- a/packages/brick_sqlite/pubspec.yaml
+++ b/packages/brick_sqlite/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_sqlite
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.1.5
+version: 0.1.5+1
 
 environment:
   sdk: '>=2.5.0 <3.0.0'


### PR DESCRIPTION
Fix: recreate SQLite DB after reset instead of attempting to open a closed DB