### PR TITLE
honor locked requests in the offline queue

### DIFF
--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.3
 
 * RequestSqliteCache no longer queries cached requests based on headers; requests are rediscovered based on their encoding, URL, request method, and body. Rehydrated (reattempted) requests will be hydrated with headers from the original request.
+* Do not reprocess queue requests during a single attempt. Server response times may be greater than the reattempt timer; in these situations, requests should remain locked.
 
 ## 0.1.2
 

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_queue_http_client.dart
@@ -55,15 +55,18 @@ class OfflineQueueHttpClient extends http.BaseClient {
       if (cacheItem.requestIsPush &&
           resp != null &&
           !reattemptForStatusCodes.contains(resp.statusCode)) {
+        final db = await requestManager.getDb();
         // request was successfully sent and can be removed
         _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
-        final db = await requestManager.getDb();
         await cacheItem.delete(db);
       }
 
       return resp ?? _genericErrorResponse;
     } catch (e) {
       _logger.warning('#send: $e');
+    } finally {
+      final db = await requestManager.getDb();
+      await cacheItem.unlock(db);
     }
 
     return _genericErrorResponse;

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -136,14 +136,23 @@ class RequestSqliteCache {
     return _request;
   }
 
-  static Future<int> unlockRequest(Map<String, dynamic> data, DatabaseExecutor db) async {
-    return await db.update(
-      HTTP_JOBS_TABLE_NAME,
-      {
-        HTTP_JOBS_LOCKED_COLUMN: 0,
-      },
-      where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
-      whereArgs: [data[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
-    );
-  }
+  static Future<int> lockRequest(Map<String, dynamic> data, DatabaseExecutor db) async =>
+      await _updateLock(true, data, db);
+  static Future<int> unlockRequest(Map<String, dynamic> data, DatabaseExecutor db) async =>
+      await _updateLock(false, data, db);
+}
+
+Future<int> _updateLock(
+  bool shouldLock,
+  Map<String, dynamic> data,
+  DatabaseExecutor db,
+) async {
+  return await db.update(
+    HTTP_JOBS_TABLE_NAME,
+    {
+      HTTP_JOBS_LOCKED_COLUMN: shouldLock ? 1 : 0,
+    },
+    where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
+    whereArgs: [data[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
+  );
 }

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -35,7 +35,7 @@ class RequestSqliteCache {
   }
 
   @protected
-  Future<Map<String, dynamic>> findRequestInDatabase(Database db) async {
+  Future<Map<String, dynamic>> findRequestInDatabase(DatabaseExecutor db) async {
     final columns = [
       HTTP_JOBS_BODY_COLUMN,
       HTTP_JOBS_ENCODING_COLUMN,
@@ -52,7 +52,7 @@ class RequestSqliteCache {
       whereArgs: columns.map((c) => serialized[c]).toList(),
     );
 
-    return response?.isNotEmpty == true ? response.first : null;
+    return response?.isNotEmpty ?? false ? response.first : null;
   }
 
   /// If the request already exists in the database, increment attemps and
@@ -79,7 +79,6 @@ class RequestSqliteCache {
         {
           HTTP_JOBS_ATTEMPTS_COLUMN: response[HTTP_JOBS_ATTEMPTS_COLUMN] + 1,
           HTTP_JOBS_UPDATED_AT: DateTime.now().millisecondsSinceEpoch,
-          HTTP_JOBS_LOCKED_COLUMN: 0, // unlock the row, this job has finished processing
         },
         where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
         whereArgs: [response[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
@@ -104,6 +103,16 @@ class RequestSqliteCache {
     };
   }
 
+  /// If the request did not succeed, unlock for subsequent processing
+  Future<int> unlock(Database db) async {
+    final response = await findRequestInDatabase(db);
+    if (response == null) return null;
+
+    return await db.transaction((txn) async {
+      return await unlockRequest(response, txn);
+    });
+  }
+
   /// Recreate a request from SQLite data
   static http.Request sqliteToRequest(Map<String, dynamic> data) {
     var _request = http.Request(
@@ -124,5 +133,16 @@ class RequestSqliteCache {
     }
 
     return _request;
+  }
+
+  static Future<int> unlockRequest(Map<String, dynamic> data, DatabaseExecutor db) async {
+    return await db.update(
+      HTTP_JOBS_TABLE_NAME,
+      {
+        HTTP_JOBS_LOCKED_COLUMN: 0, // unlock the row, this job has finished processing
+      },
+      where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
+      whereArgs: [data[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
+    );
   }
 }

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -63,6 +63,7 @@ class RequestSqliteCache {
     return db.transaction((txn) async {
       if (response == null || response.isEmpty) {
         final serialized = toSqlite();
+        serialized[HTTP_JOBS_LOCKED_COLUMN] = 1;
 
         logger?.fine('adding to queue: $serialized');
         return await txn.insert(
@@ -79,6 +80,7 @@ class RequestSqliteCache {
         {
           HTTP_JOBS_ATTEMPTS_COLUMN: response[HTTP_JOBS_ATTEMPTS_COLUMN] + 1,
           HTTP_JOBS_UPDATED_AT: DateTime.now().millisecondsSinceEpoch,
+          HTTP_JOBS_LOCKED_COLUMN: 1,
         },
         where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
         whereArgs: [response[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
@@ -138,7 +140,7 @@ class RequestSqliteCache {
     return await db.update(
       HTTP_JOBS_TABLE_NAME,
       {
-        HTTP_JOBS_LOCKED_COLUMN: 0, // unlock the row, this job has finished processing
+        HTTP_JOBS_LOCKED_COLUMN: 0,
       },
       where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
       whereArgs: [data[HTTP_JOBS_PRIMARY_KEY_COLUMN]],

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache.dart
@@ -105,10 +105,9 @@ class RequestSqliteCache {
 
   /// If the request did not succeed, unlock for subsequent processing
   Future<int> unlock(Database db) async {
-    final response = await findRequestInDatabase(db);
-    if (response == null) return null;
-
     return await db.transaction((txn) async {
+      final response = await findRequestInDatabase(txn);
+      if (response == null) return null;
       return await unlockRequest(response, txn);
     });
   }

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -86,7 +86,7 @@ class RequestSqliteCacheManager {
       final unlockedRequests = await _latestRequest(txn, whereLocked: false);
       if (unlockedRequests?.isEmpty ?? true) return [];
       // lock the latest unlocked request
-      await _lockRequest(txn, unlockedRequests.first);
+      await RequestSqliteCache.lockRequest(unlockedRequests.first, txn);
 
       // return the next unlocked request (now locked)
       return unlockedRequests;
@@ -182,17 +182,6 @@ class RequestSqliteCacheManager {
       whereArgs: [whereLocked ? 1 : 0, nowMinusNextPoll],
       orderBy: orderByStatement,
       limit: 1,
-    );
-  }
-
-  Future<void> _lockRequest(DatabaseExecutor txn, Map<String, dynamic> request) async {
-    await txn.update(
-      HTTP_JOBS_TABLE_NAME,
-      {
-        HTTP_JOBS_LOCKED_COLUMN: 1,
-      },
-      where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
-      whereArgs: [request[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
     );
   }
 }

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -76,8 +76,6 @@ class RequestSqliteCacheManager {
         final twoMinutesAgo = DateTime.now().subtract(Duration(minutes: 2));
         if (lastUpdated.isBefore(twoMinutesAgo)) {
           await RequestSqliteCache.unlockRequest(latestLockedRequests.first, txn);
-        } else {
-          return [];
         }
         if (serialProcessing) return [];
       }

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -91,7 +91,7 @@ class RequestSqliteCacheManager {
 
     final jobs = unprocessedRequests.map(RequestSqliteCache.sqliteToRequest).cast<http.Request>();
 
-    if (jobs?.isEmpty ?? true) return null;
+    if (jobs?.isNotEmpty ?? false) return jobs.first;
 
     // lock the request for idempotency
 

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -4,6 +4,7 @@ import 'package:brick_offline_first/src/offline_queue/request_sqlite_cache_manag
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:http/http.dart' as http;
 import '__helpers__.dart';
 
 void main() {
@@ -52,21 +53,89 @@ void main() {
       expect(req.method, 'PUT');
     });
 
-    test('#prepareNextRequestToProcess', () async {
-      final inner = stubResult(requestBody: 'existing record', statusCode: 501);
-      final client = OfflineQueueHttpClient(inner, requestManager);
+    group('#prepareNextRequestToProcess', () {
+      test('integration', () async {
+        final inner = stubResult(requestBody: 'existing record', statusCode: 501);
+        final client = OfflineQueueHttpClient(inner, requestManager);
 
-      await client.post('http://localhost:3000', body: 'existing record');
-      await client.put('http://localhost:3000', body: 'existing record');
+        await client.post('http://localhost:3000', body: 'existing record');
+        await client.put('http://localhost:3000', body: 'existing record');
 
-      final request = await requestManager.prepareNextRequestToProcess();
-      expect(request.method, 'POST');
+        final request = await requestManager.prepareNextRequestToProcess();
+        expect(request?.method, isNull);
 
-      final asCacheItem = RequestSqliteCache(request);
-      await asCacheItem.insertOrUpdate(await requestManager.getDb());
-      // Do not retry request if the row is locked and serial processing is active
-      final req = await requestManager.prepareNextRequestToProcess();
-      expect(req, isNull);
+        final asCacheItem = RequestSqliteCache(request);
+        await asCacheItem.insertOrUpdate(await requestManager.getDb());
+        // Do not retry request if the row is locked and serial processing is active
+        final req = await requestManager.prepareNextRequestToProcess();
+        expect(req, isNull);
+      });
+
+      test('new request is locked and skipped', () async {
+        final request = http.Request("POST", Uri.parse("http://localhost:3000/locked_request"));
+
+        // prepare unlocked request
+        final asCacheItem = RequestSqliteCache(request);
+        await asCacheItem.insertOrUpdate(await requestManager.getDb());
+
+        final requests = await requestManager.unprocessedRequests(onlyLocked: true);
+        expect(requests, hasLength(1));
+
+        final req = await requestManager.prepareNextRequestToProcess();
+        expect(req, isNull);
+      });
+
+      test('unlocked request is locked', () async {
+        final request = http.Request("POST", Uri.parse("http://localhost:3000/unlocked_request"));
+
+        // prepare unlocked request
+        final asCacheItem = RequestSqliteCache(request);
+        await asCacheItem.insertOrUpdate(await requestManager.getDb());
+        await asCacheItem.unlock(await requestManager.getDb());
+
+        final requests = await requestManager.unprocessedRequests(onlyLocked: false);
+        expect(requests, hasLength(1));
+
+        final lockedRequests = await requestManager.unprocessedRequests(onlyLocked: true);
+        expect(lockedRequests, isEmpty);
+
+        final req = await requestManager.prepareNextRequestToProcess();
+        expect(req.url, Uri.parse('http://localhost:3000/unlocked_request'));
+
+        final newLockedRequests = await requestManager.unprocessedRequests(onlyLocked: true);
+        expect(newLockedRequests, hasLength(1));
+      });
+
+      test('locked request older than 2 minutes is unlocked', () async {
+        final request = http.Request("POST", Uri.parse("http://localhost:3000/old_request"));
+        final db = await requestManager.getDb();
+        // prepare unlocked request
+        final asCacheItem = RequestSqliteCache(request);
+        await asCacheItem.insertOrUpdate(await requestManager.getDb());
+        expect(await requestManager.prepareNextRequestToProcess(), isNull);
+
+        // ignore: invalid_use_of_protected_member
+        final response = await asCacheItem.findRequestInDatabase(db);
+        await db.update(
+          HTTP_JOBS_TABLE_NAME,
+          {
+            HTTP_JOBS_UPDATED_AT:
+                DateTime.now().subtract(Duration(seconds: 122)).millisecondsSinceEpoch,
+          },
+          where: '$HTTP_JOBS_PRIMARY_KEY_COLUMN = ?',
+          whereArgs: [response[HTTP_JOBS_PRIMARY_KEY_COLUMN]],
+        );
+
+        expect(await requestManager.unprocessedRequests(onlyLocked: true), hasLength(1));
+        expect(await requestManager.unprocessedRequests(onlyLocked: false), hasLength(1));
+
+        expect(await requestManager.prepareNextRequestToProcess(), isNull);
+
+        final updatedReq = await requestManager.prepareNextRequestToProcess();
+        expect(updatedReq.url, Uri.parse('http://localhost:3000/old_request'));
+
+        expect(await requestManager.unprocessedRequests(onlyLocked: true), hasLength(1));
+      });
     });
 
     test('#deleteUnprocessedRequest', () async {

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -64,8 +64,9 @@ void main() {
 
       final asCacheItem = RequestSqliteCache(request);
       await asCacheItem.insertOrUpdate(await requestManager.getDb());
+      // Do not retry request if the row is locked and serial processing is active
       final req = await requestManager.prepareNextRequestToProcess();
-      expect(req.method, 'POST');
+      expect(req, isNull);
     });
 
     test('#deleteUnprocessedRequest', () async {

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_manager_test.dart
@@ -62,7 +62,7 @@ void main() {
         await client.put('http://localhost:3000', body: 'existing record');
 
         final request = await requestManager.prepareNextRequestToProcess();
-        expect(request?.method, isNull);
+        expect(request?.method, 'POST');
 
         final asCacheItem = RequestSqliteCache(request);
         await asCacheItem.insertOrUpdate(await requestManager.getDb());

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -95,6 +95,18 @@ void main() {
       });
     });
 
+    test('#unlock', () async {
+      final logger = MockLogger();
+      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+      final uninserted = RequestSqliteCache(uninsertedRequest);
+      final db = await requestManager.getDb();
+      expect(await requestManager.unprocessedRequests(), isEmpty);
+      await uninserted.insertOrUpdate(db, logger: logger);
+      await uninserted.unlock(db);
+      final request = await requestManager.unprocessedRequests();
+      expect(request.first[HTTP_JOBS_LOCKED_COLUMN], 0);
+    });
+
     group('.toRequest', () {
       test('basic', () {
         final request = RequestSqliteCache.sqliteToRequest({

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -146,6 +146,22 @@ void main() {
       });
     });
 
+    test('.lockRequest', () async {
+      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+      final uninserted = RequestSqliteCache(uninsertedRequest);
+      final db = await requestManager.getDb();
+      await uninserted.insertOrUpdate(db);
+      final lockedRequests = await requestManager.unprocessedRequests(onlyLocked: true);
+      await RequestSqliteCache.unlockRequest(lockedRequests.first, await requestManager.getDb());
+
+      var requests = await requestManager.unprocessedRequests();
+      expect(requests.first[HTTP_JOBS_LOCKED_COLUMN], 0);
+      await RequestSqliteCache.lockRequest(requests.first, await requestManager.getDb());
+
+      requests = await requestManager.unprocessedRequests();
+      expect(requests.first[HTTP_JOBS_LOCKED_COLUMN], 1);
+    });
+
     test('.unlockRequest', () async {
       final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
       final uninserted = RequestSqliteCache(uninsertedRequest);

--- a/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
+++ b/packages/brick_offline_first/test/offline_queue/request_sqlite_cache_test.dart
@@ -145,5 +145,17 @@ void main() {
         expect(request.body, '');
       });
     });
+
+    test('.unlockRequest', () async {
+      final uninsertedRequest = http.Request('GET', Uri.parse('http://uninserted.com'));
+      final uninserted = RequestSqliteCache(uninsertedRequest);
+      final db = await requestManager.getDb();
+      await uninserted.insertOrUpdate(db);
+      final requests = await requestManager.unprocessedRequests(onlyLocked: true);
+      expect(requests, hasLength(1));
+      await RequestSqliteCache.unlockRequest(requests.first, await requestManager.getDb());
+      final newLockedRequests = await requestManager.unprocessedRequests(onlyLocked: true);
+      expect(newLockedRequests, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
Do not reprocess queue requests during an attempt. Server response times may be greater than the reattempt timer; in these situations, requests should remain locked.