### PR TITLE
do not rerun timer before queue operation has completed

### DIFF
--- a/packages/brick_offline_first/CHANGELOG.md
+++ b/packages/brick_offline_first/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 0.1.4
+
+* Introduce mutex around processing in the `OfflineRequestQueue`. This will avoid simultaneous DB writes on different isolates* while a previous operation is still performing. 
+
+*Or sub routines? Microtasks? It's unclear how Timer moves its work to the background or how to force it to remain in the original "thread."
+
 ## 0.1.3
 
 * RequestSqliteCache no longer queries cached requests based on headers; requests are rediscovered based on their encoding, URL, request method, and body. Rehydrated (reattempted) requests will be hydrated with headers from the original request.

--- a/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/offline_request_queue.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'offline_queue_http_client.dart';
@@ -45,8 +46,12 @@ class OfflineRequestQueue {
   void process(Timer _timer) async {
     if (_processingInBackground) return;
     _processingInBackground = true;
-    final request = await client.requestManager.prepareNextRequestToProcess();
-    _processingInBackground = false;
+    http.Request request;
+    try {
+      request = await client.requestManager.prepareNextRequestToProcess();
+    } finally {
+      _processingInBackground = false;
+    }
 
     if (request != null) {
       _logger.finest('Processing request ${request.method} ${request.url}');

--- a/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
+++ b/packages/brick_offline_first/lib/src/offline_queue/request_sqlite_cache_manager.dart
@@ -94,8 +94,6 @@ class RequestSqliteCacheManager {
 
     if (jobs?.isNotEmpty ?? false) return jobs.first;
 
-    // lock the request for idempotency
-
     return null;
   }
 

--- a/packages/brick_offline_first/pubspec.yaml
+++ b/packages/brick_offline_first/pubspec.yaml
@@ -5,11 +5,11 @@ homepage: https://github.com/greenbits/brick/tree/master/packages/brick_offline_
 issue_tracker: https://github.com/greenbits/brick/issues
 repository: https://github.com/greenbits/brick
 
-version: 0.1.3
+version: 0.1.4
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
-  flutter: '>=1.8.0 <2.0.0'
+  sdk: ">=2.6.0 <3.0.0"
+  flutter: ">=1.8.0 <2.0.0"
 
 dependencies:
   brick_core: ^0.0.6


### PR DESCRIPTION
Introduce mutex around processing in the `OfflineRequestQueue`. This will avoid simultaneous DB writes on different isolates* while a previous operation is still performing. 

*Or sub routines? Microtasks? It's unclear how Timer moves its work to the background or how to force it to remain in the original "thread."