### PR TITLE
add lock around exists and delete statements

### DIFF
--- a/packages/brick_sqlite/CHANGELOG.md
+++ b/packages/brick_sqlite/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Fix edge case where 'ambiguous column name' was thrown on `exists` queries with an association constraint and declared `OFFSET`
+* Wrap `SqliteProvider#exists` and `SqliteProvider#delete` in the synchronous lock to prevent simultaneous operation. All other operations also use the lock. 
 
 ## 0.1.7
 


### PR DESCRIPTION
Wrap `SqliteProvider#exists` and `SqliteProvider#delete` in the synchronous lock to prevent simultaneous operation. All other operations also use the lock.